### PR TITLE
Merge approvers and whitelisted users, move to config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The `gh` CLI is authenticated as @ClaydeCode and git is configured with my name 
     {owner}__{repo}/      # cloned repos (naming: owner__repo)
   src/clayde/
     __init__.py
-    config.py             # CLAYDE_DIR, paths, APPROVER, WHITELISTED_USERS,
+    config.py             # CLAYDE_DIR, paths, WHITELISTED_USERS,
                           #   load_config(), setup_logging(), get_github_client()
     state.py              # load_state(), save_state(), get_issue_state(),
                           #   update_issue_state()
@@ -77,6 +77,7 @@ Plain `KEY=VALUE` file (no shell quoting). Keys:
 | `GITHUB_TOKEN` | Fine-grained PAT with Issues R/W, Pull Requests R/W, Contents R/W |
 | `GITHUB_USERNAME` | `ClaydeCode` |
 | `CLAYDE_ENABLED` | Set to `true` to activate; any other value causes immediate exit |
+| `WHITELISTED_USERS` | Comma-separated list of trusted GitHub usernames (e.g. `max-tet,ClaydeCode`) |
 
 Config is loaded by `load_config()` and `GH_TOKEN` is exported from it at startup.
 
@@ -110,9 +111,9 @@ Interrupted entries also store: `interrupted_phase` (`"planning"` or `"implement
 Two independent checks must pass before any work begins:
 
 1. **Issue-level gate** (before planning): issue must be created by a whitelisted user OR have a 👍 reaction from a whitelisted user on the issue itself.
-2. **Plan approval gate** (before implementation): the plan comment must have a 👍 reaction from `APPROVER` (`max-tet`) AND the issue itself must have a 👍 from a whitelisted user.
+2. **Plan approval gate** (before implementation): the plan comment must have a 👍 reaction from any whitelisted user.
 
-Whitelisted users: `["max-tet"]` (defined in `config.py`).
+Whitelisted users: configured via `WHITELISTED_USERS` in `config.env` (comma-separated).
 
 ---
 
@@ -142,7 +143,7 @@ Repo cloning convention: `repos/{owner}__{repo}/` (double underscore separator).
 ## Safety Gates (`safety.py`)
 
 - `is_issue_authorized(issue)` — True if issue author is whitelisted OR a whitelisted user reacted +1.
-- `is_plan_approved(g, owner, repo, number, comment_id)` — True if APPROVER reacted +1 to plan comment AND a whitelisted user reacted +1 to the issue.
+- `is_plan_approved(g, owner, repo, number, comment_id)` — True if a whitelisted user reacted +1 to the plan comment.
 
 ---
 

--- a/src/clayde/config.py
+++ b/src/clayde/config.py
@@ -9,8 +9,7 @@ CLAYDE_DIR = "/home/ubuntu/clayde"
 STATE_FILE = os.path.join(CLAYDE_DIR, "state.json")
 LOG_FILE = os.path.join(CLAYDE_DIR, "logs", "agent.log")
 REPOS_DIR = os.path.join(CLAYDE_DIR, "repos")
-APPROVER = "max-tet"
-WHITELISTED_USERS = ["max-tet", "ClaydeCode"]
+WHITELISTED_USERS: list[str] = []
 
 
 def load_config():
@@ -22,6 +21,8 @@ def load_config():
             if line and not line.startswith("#") and "=" in line:
                 key, _, value = line.partition("=")
                 config[key.strip()] = value.strip()
+    raw = config.get("WHITELISTED_USERS", "max-tet,ClaydeCode")
+    WHITELISTED_USERS[:] = [u.strip() for u in raw.split(",") if u.strip()]
     return config
 
 

--- a/src/clayde/safety.py
+++ b/src/clayde/safety.py
@@ -2,7 +2,7 @@
 
 from github import Github
 
-from clayde.config import APPROVER, WHITELISTED_USERS
+from clayde.config import WHITELISTED_USERS
 
 
 def is_issue_authorized(issue) -> bool:
@@ -13,15 +13,10 @@ def is_issue_authorized(issue) -> bool:
 
 
 def is_plan_approved(g: Github, owner: str, repo: str, number: int, comment_id: int) -> bool:
-    """Return True if APPROVER reacted +1 to the plan comment AND a whitelisted user reacted +1 to the issue."""
+    """Return True if a whitelisted user reacted +1 to the plan comment."""
     repo_obj = g.get_repo(f"{owner}/{repo}")
-    issue = repo_obj.get_issue(number)
-    comment = repo_obj.get_comment(comment_id)
-    approver_approved = any(
-        r.content == "+1" and r.user.login == APPROVER
-        for r in comment.get_reactions()
-    )
-    return approver_approved and _has_whitelisted_reaction(issue.get_reactions())
+    comment = repo_obj.get_issue_comment(comment_id)
+    return _has_whitelisted_reaction(comment.get_reactions())
 
 
 def _has_whitelisted_reaction(reactions) -> bool:


### PR DESCRIPTION
Closes #6

## Summary
- Removed the separate `APPROVER` constant — there is now one unified `WHITELISTED_USERS` list
- `WHITELISTED_USERS` is loaded from `config.env` (comma-separated) instead of being hardcoded in `config.py`
- Simplified plan approval: a +1 from any whitelisted user on the plan comment is sufficient (no longer requires a separate +1 on the issue itself)
- Updated `CLAUDE.md` documentation to reflect the new unified concept and simplified approval logic

## Test plan
- [ ] Verify `WHITELISTED_USERS` is correctly parsed from `config.env`
- [ ] Verify plan approval works with only a +1 on the plan comment
- [ ] Verify no references to `APPROVER` remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)