### PR TITLE
Fix #13: Better branch naming with descriptive slugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ The `gh` CLI is authenticated as @ClaydeCode and git is configured with my name 
                           #   update_issue_state()
     github.py             # PyGitHub wrappers: parse_issue_url(), fetch_issue(),
                           #   fetch_issue_comments(), post_comment(), fetch_comment(),
-                          #   get_default_branch(), get_assigned_issues(), find_open_pr()
+                          #   get_default_branch(), get_assigned_issues(),
+                          #   extract_branch_name(), find_open_pr()
     git.py                # ensure_repo() — clone or update repos under REPOS_DIR
     safety.py             # is_issue_authorized(), is_plan_approved() — safety gates
     claude.py             # invoke_claude(prompt, repo_path) — subprocess to claude CLI
@@ -101,7 +102,7 @@ Issue lifecycle stored in `state.json` under `{"issues": {"<html_url>": {...}}}`
 | `failed` | Error during plan or implement; cleared manually to retry |
 | `interrupted` | Claude usage/rate limit hit mid-task; retried automatically each cron tick |
 
-State entries also store: `owner`, `repo`, `number`, `plan_comment_id`, `pr_url`.
+State entries also store: `owner`, `repo`, `number`, `plan_comment_id`, `pr_url`, `branch_name`.
 Interrupted entries also store: `interrupted_phase` (`"planning"` or `"implementing"`).
 
 ---
@@ -163,7 +164,7 @@ Repo cloning convention: `repos/{owner}__{repo}/` (double underscore separator).
 1. Fetch plan comment text and any discussion comments posted after the plan
 2. `ensure_repo()` to reset to latest default branch
 3. Build prompt with issue body, plan, discussion, repo path
-4. `invoke_claude()` — Claude creates a branch (`clayde/issue-{number}`), implements, commits, pushes, opens PR, outputs PR URL as last line
+4. `invoke_claude()` — Claude creates a branch (`clayde/issue-{number}-{slug}`, where the slug is extracted from the plan), implements, commits, pushes, opens PR, outputs PR URL as last line
 5. Parse PR URL from last line of Claude output via regex
 6. Post result comment on issue; set status → `done`
 

--- a/src/clayde/github.py
+++ b/src/clayde/github.py
@@ -46,10 +46,17 @@ def get_assigned_issues(g: Github) -> list:
         return []
 
 
-def find_open_pr(g: Github, owner: str, repo: str, number: int) -> str | None:
-    """Return the HTML URL of an open PR for clayde/issue-{number}, or None."""
-    branch = f"clayde/issue-{number}"
+def extract_branch_name(plan_text: str, number: int) -> str:
+    """Extract branch name from plan text, falling back to clayde/issue-{number}."""
+    m = re.search(r"\*\*Branch:\*\*\s*`(clayde/issue-\d+-[a-z0-9-]+)`", plan_text)
+    if m:
+        return m.group(1)
+    return f"clayde/issue-{number}"
+
+
+def find_open_pr(g: Github, owner: str, repo: str, branch_name: str) -> str | None:
+    """Return the HTML URL of an open PR for the given branch, or None."""
     pulls = list(g.get_repo(f"{owner}/{repo}").get_pulls(
-        state="open", head=f"{owner}:{branch}"
+        state="open", head=f"{owner}:{branch_name}"
     ))
     return pulls[0].html_url if pulls else None

--- a/src/clayde/prompts/implement.j2
+++ b/src/clayde/prompts/implement.j2
@@ -14,14 +14,14 @@ ADDITIONAL COMMENTS/INSTRUCTIONS FROM DISCUSSION:
 REPOSITORY ON DISK: {{ repo_path }}
 
 Steps:
-1. Before creating a branch or PR, check whether branch `clayde/issue-{{ number }}` or a PR for this issue already exists. If so, resume from the existing state rather than starting fresh.
-2. Create or switch to branch: git checkout -b clayde/issue-{{ number }} (or git checkout clayde/issue-{{ number }} if it exists)
+1. Before creating a branch or PR, check whether branch `{{ branch_name }}` or a PR for this issue already exists. If so, resume from the existing state rather than starting fresh.
+2. Create or switch to branch: git checkout -b {{ branch_name }} (or git checkout {{ branch_name }} if it exists)
 3. Implement the plan carefully, following existing code style and paying attention to agents.md files if they exist
 4. Write or update tests if applicable
 5. Run tests if a test command is discoverable (check CLAUDE.md, README, Makefile, package.json, pyproject.toml, justfile)
 6. Review your own changes for correctness, edge cases, and style and run "just cleanup" if it exists before committing
 7. Commit with a clear message, e.g.: "Fix #{{ number }}: <summary>"
-8. Push: git push origin clayde/issue-{{ number }}
+8. Push: git push origin {{ branch_name }}
 9. Create PR (if one doesn't already exist): gh pr create --repo {{ owner }}/{{ repo }} --title "..." --body "Closes #{{ number }}\n\n<description>"
 
 Output the PR URL as the LAST line of your response.

--- a/src/clayde/prompts/plan.j2
+++ b/src/clayde/prompts/plan.j2
@@ -21,7 +21,15 @@ Then produce a plan that includes:
 - Edge cases and risks
 - How to verify the implementation is correct
 
+At the end of your plan, include a branch name suggestion on its own line in
+exactly this format:
+
+**Branch:** `clayde/issue-{{ number }}-<slug>`
+
+where `<slug>` is a 1-to-3 word lowercase hyphenated description of the issue
+(e.g., `clayde/issue-13-better-branch-naming`). This MUST be present.
+
 If anything is ambiguous or you need clarification, include your questions
-at the end under a "Questions" section.
+at the end under a "Questions" section (before the branch name line).
 
 Output ONLY the plan in markdown format. No preamble, no wrapping.

--- a/src/clayde/tasks/implement.py
+++ b/src/clayde/tasks/implement.py
@@ -10,6 +10,7 @@ from clayde.claude import UsageLimitError, invoke_claude
 from clayde.config import get_github_client
 from clayde.git import ensure_repo
 from clayde.github import (
+    extract_branch_name,
     fetch_comment,
     fetch_issue,
     fetch_issue_comments,
@@ -33,7 +34,8 @@ def run(issue_url: str) -> None:
 
     # If resuming from an interrupted implementation, check for an existing PR.
     if issue_state.get("status") == "interrupted":
-        existing_pr = find_open_pr(g, owner, repo, number)
+        branch_name = issue_state.get("branch_name", f"clayde/issue-{number}")
+        existing_pr = find_open_pr(g, owner, repo, branch_name)
         if existing_pr:
             log.info("Resuming interrupted #%d — found existing PR %s", number, existing_pr)
             post_comment(g, owner, repo, number, f"Implementation complete — PR opened: {existing_pr}")
@@ -49,10 +51,13 @@ def run(issue_url: str) -> None:
     plan_comment = fetch_comment(g, owner, repo, number, plan_comment_id)
     plan_text = plan_comment.body
 
+    branch_name = issue_state.get("branch_name") or extract_branch_name(plan_text, number)
+    update_issue_state(issue_url, {"branch_name": branch_name})
+
     all_comments = fetch_issue_comments(g, owner, repo, number)
     discussion_text = _collect_discussion(all_comments, plan_comment_id)
 
-    prompt = _build_prompt(issue, plan_text, discussion_text, owner, repo, number, repo_path)
+    prompt = _build_prompt(issue, plan_text, discussion_text, owner, repo, number, repo_path, branch_name)
 
     log.info("Invoking Claude for implementation of issue #%d", number)
     try:
@@ -80,7 +85,7 @@ def _collect_discussion(all_comments, plan_comment_id: int) -> str:
     return "\n---\n".join(discussion) or "(none)"
 
 
-def _build_prompt(issue, plan_text: str, discussion_text: str, owner: str, repo: str, number: int, repo_path: str) -> str:
+def _build_prompt(issue, plan_text: str, discussion_text: str, owner: str, repo: str, number: int, repo_path: str, branch_name: str) -> str:
     template_src = (_PROMPTS_DIR / "implement.j2").read_text()
     return Environment(undefined=StrictUndefined).from_string(template_src).render(
         number=number,
@@ -91,6 +96,7 @@ def _build_prompt(issue, plan_text: str, discussion_text: str, owner: str, repo:
         plan_text=plan_text,
         discussion_text=discussion_text,
         repo_path=repo_path,
+        branch_name=branch_name,
     )
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -6,6 +6,7 @@ import pytest
 from github import GithubException
 
 from clayde.github import (
+    extract_branch_name,
     fetch_comment,
     fetch_issue,
     fetch_issue_comments,
@@ -96,19 +97,33 @@ class TestGetAssignedIssues:
         assert result == []
 
 
+class TestExtractBranchName:
+    def test_extracts_from_plan(self):
+        plan = "Some plan text\n\n**Branch:** `clayde/issue-13-better-branch`\n"
+        assert extract_branch_name(plan, 13) == "clayde/issue-13-better-branch"
+
+    def test_fallback_when_missing(self):
+        plan = "Some plan text without branch name"
+        assert extract_branch_name(plan, 7) == "clayde/issue-7"
+
+    def test_extracts_with_surrounding_text(self):
+        plan = "Plan\n**Branch:** `clayde/issue-5-fix-bug`\nMore text"
+        assert extract_branch_name(plan, 5) == "clayde/issue-5-fix-bug"
+
+
 class TestFindOpenPr:
     def test_returns_url_when_pr_exists(self):
         g = MagicMock()
         mock_pr = MagicMock()
         mock_pr.html_url = "https://github.com/alice/repo/pull/10"
         g.get_repo.return_value.get_pulls.return_value = [mock_pr]
-        result = find_open_pr(g, "alice", "repo", 5)
+        result = find_open_pr(g, "alice", "repo", "clayde/issue-5-fix-bug")
         g.get_repo.return_value.get_pulls.assert_called_once_with(
-            state="open", head="alice:clayde/issue-5"
+            state="open", head="alice:clayde/issue-5-fix-bug"
         )
         assert result == "https://github.com/alice/repo/pull/10"
 
     def test_returns_none_when_no_pr(self):
         g = MagicMock()
         g.get_repo.return_value.get_pulls.return_value = []
-        assert find_open_pr(g, "alice", "repo", 5) is None
+        assert find_open_pr(g, "alice", "repo", "clayde/issue-5-fix-bug") is None

--- a/tests/test_tasks_implement.py
+++ b/tests/test_tasks_implement.py
@@ -139,10 +139,11 @@ class TestRun:
         issue.title = "Test issue"
         issue.body = "Fix this bug"
 
-        prompt = _build_prompt(issue, "plan text", "discussion", "owner", "repo", 42, "/tmp/repo")
+        prompt = _build_prompt(issue, "plan text", "discussion", "owner", "repo", 42, "/tmp/repo", "clayde/issue-42-test-branch")
         assert "Test issue" in prompt
         assert "Fix this bug" in prompt
         assert "plan text" in prompt
         assert "discussion" in prompt
         assert "/tmp/repo" in prompt
         assert "42" in prompt
+        assert "clayde/issue-42-test-branch" in prompt


### PR DESCRIPTION
Closes #13

## Summary

- Claude now generates a descriptive branch name slug during the plan phase (e.g., `clayde/issue-13-better-branch-naming`)
- `extract_branch_name()` parses the slug from the plan text, with fallback to `clayde/issue-{number}`
- `find_open_pr()` accepts a full branch name instead of constructing one from the issue number
- Branch name is persisted in `state.json` for reliable interrupted-resume handling
- Updated `implement.j2` template to use the `branch_name` variable throughout
- Updated `plan.j2` to instruct Claude to include a `**Branch:** \`clayde/issue-N-slug\`` line

## Test plan

- [x] All 99 existing tests pass
- [x] New `TestExtractBranchName` tests cover extraction and fallback
- [x] Updated `TestFindOpenPr` tests use branch name strings
- [x] Updated `test_build_prompt_uses_real_template` verifies branch name in rendered prompt