### PR TITLE
Fix #11: Use pydantic-settings for configuration

### DIFF
--- a/config.env.template
+++ b/config.env.template
@@ -1,0 +1,6 @@
+# Clayde configuration — copy to config.env and fill in values
+CLAYDE_GITHUB_TOKEN=
+CLAYDE_GITHUB_USERNAME=ClaydeCode
+CLAYDE_ENABLED=false
+CLAYDE_WHITELISTED_USERS_RAW=max-tet,ClaydeCode
+CLAYDE_DIR=/home/ubuntu/clayde

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Clayde — autonomous GitHub issue agent"
 requires-python = ">=3.12"
 dependencies = [
     "jinja2>=3.1.6",
+    "pydantic-settings>=2.0",
     "PyGitHub>=2.5.0",
 ]
 

--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 
-from clayde.config import CLAYDE_DIR
+from clayde.config import get_settings
 
 log = logging.getLogger("clayde.claude")
 
@@ -40,7 +40,7 @@ def invoke_claude(prompt, repo_path):
 
     Raises UsageLimitError if the Claude CLI reports a usage/rate limit.
     """
-    identity = open(os.path.join(CLAYDE_DIR, "CLAUDE.md")).read()
+    identity = open(os.path.join(str(get_settings().dir), "CLAUDE.md")).read()
 
     result = subprocess.run(
         [

--- a/src/clayde/config.py
+++ b/src/clayde/config.py
@@ -1,40 +1,71 @@
-"""Configuration constants, config loading, and logging setup."""
+"""Configuration via pydantic-settings."""
 
 import logging
 import os
+from pathlib import Path
 
 from github import Auth, Github
+from pydantic import computed_field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-CLAYDE_DIR = "/home/ubuntu/clayde"
-STATE_FILE = os.path.join(CLAYDE_DIR, "state.json")
-LOG_FILE = os.path.join(CLAYDE_DIR, "logs", "agent.log")
-REPOS_DIR = os.path.join(CLAYDE_DIR, "repos")
-WHITELISTED_USERS: list[str] = []
+_settings: "Settings | None" = None
 
 
-def load_config():
-    """Parse config.env into a dict."""
-    config = {}
-    with open(os.path.join(CLAYDE_DIR, "config.env")) as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                key, _, value = line.partition("=")
-                config[key.strip()] = value.strip()
-    raw = config.get("WHITELISTED_USERS", "max-tet,ClaydeCode")
-    WHITELISTED_USERS[:] = [u.strip() for u in raw.split(",") if u.strip()]
-    return config
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="CLAYDE_",
+        env_file=os.path.join(os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde"), "config.env"),
+        env_file_encoding="utf-8",
+    )
+
+    github_token: str = ""
+    github_username: str = "ClaydeCode"
+    enabled: bool = False
+    whitelisted_users_raw: str = "max-tet,ClaydeCode"
+    dir: Path = Path("/home/ubuntu/clayde")
+
+    @computed_field
+    @property
+    def whitelisted_users(self) -> list[str]:
+        return [u.strip() for u in self.whitelisted_users_raw.split(",") if u.strip()]
+
+    @property
+    def state_file(self) -> str:
+        return str(self.dir / "state.json")
+
+    @property
+    def log_file(self) -> str:
+        return str(self.dir / "logs" / "agent.log")
+
+    @property
+    def repos_dir(self) -> str:
+        return str(self.dir / "repos")
 
 
-def get_github_client() -> Github:
-    """Return an authenticated PyGitHub client using GH_TOKEN from the environment."""
-    return Github(auth=Auth.Token(os.environ["GH_TOKEN"]))
+def get_settings() -> Settings:
+    """Return the cached Settings singleton."""
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings
 
 
-def setup_logging():
+def _reset_settings() -> None:
+    """Clear the cached settings (for testing)."""
+    global _settings
+    _settings = None
+
+
+def get_github_client() -> "Github":
+    """Return an authenticated PyGitHub client."""
+    return Github(auth=Auth.Token(get_settings().github_token))
+
+
+def setup_logging() -> None:
     """Configure stdlib logging to append to the agent log file."""
-    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-    handler = logging.FileHandler(LOG_FILE)
+    log_file = get_settings().log_file
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    handler = logging.FileHandler(log_file)
     handler.setFormatter(logging.Formatter(
         "[%(asctime)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/src/clayde/git.py
+++ b/src/clayde/git.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 
-from clayde.config import REPOS_DIR
+from clayde.config import get_settings
 
 log = logging.getLogger("clayde.git")
 
@@ -14,7 +14,8 @@ def ensure_repo(owner: str, repo: str, default_branch: str) -> str:
 
     Returns the local path to the repository.
     """
-    repo_path = os.path.join(REPOS_DIR, f"{owner}__{repo}")
+    repos_dir = get_settings().repos_dir
+    repo_path = os.path.join(repos_dir, f"{owner}__{repo}")
     clone_url = f"https://github.com/{owner}/{repo}.git"
 
     if os.path.isdir(os.path.join(repo_path, ".git")):
@@ -26,7 +27,7 @@ def ensure_repo(owner: str, repo: str, default_branch: str) -> str:
         subprocess.run(["git", "pull"], cwd=repo_path, capture_output=True)
     else:
         log.info("Cloning %s/%s", owner, repo)
-        os.makedirs(REPOS_DIR, exist_ok=True)
+        os.makedirs(repos_dir, exist_ok=True)
         result = subprocess.run(
             ["git", "clone", clone_url, repo_path],
             capture_output=True, text=True,

--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from clayde.claude import is_claude_available
-from clayde.config import get_github_client, load_config, setup_logging
+from clayde.config import get_github_client, get_settings, setup_logging
 from clayde.github import get_assigned_issues
 from clayde.safety import is_issue_authorized, is_plan_approved
 from clayde.state import load_state, update_issue_state
@@ -63,12 +63,12 @@ def _handle_interrupted(url: str, entry: dict) -> None:
 
 
 def main():
-    config = load_config()
+    settings = get_settings()
 
-    if config.get("CLAYDE_ENABLED", "false").lower() != "true":
+    if not settings.enabled:
         sys.exit(0)
 
-    os.environ["GH_TOKEN"] = config["GITHUB_TOKEN"]
+    os.environ["GH_TOKEN"] = settings.github_token
 
     setup_logging()
 

--- a/src/clayde/safety.py
+++ b/src/clayde/safety.py
@@ -2,12 +2,12 @@
 
 from github import Github
 
-from clayde.config import WHITELISTED_USERS
+from clayde.config import get_settings
 
 
 def is_issue_authorized(issue) -> bool:
     """Return True if the issue author is whitelisted OR a whitelisted user reacted +1."""
-    if issue.user.login in WHITELISTED_USERS:
+    if issue.user.login in get_settings().whitelisted_users:
         return True
     return _has_whitelisted_reaction(issue.get_reactions())
 
@@ -20,6 +20,6 @@ def is_plan_approved(g: Github, owner: str, repo: str, number: int, comment_id: 
 
 def _has_whitelisted_reaction(reactions) -> bool:
     return any(
-        r.content == "+1" and r.user.login in WHITELISTED_USERS
+        r.content == "+1" and r.user.login in get_settings().whitelisted_users
         for r in reactions
     )

--- a/src/clayde/state.py
+++ b/src/clayde/state.py
@@ -4,20 +4,21 @@ import json
 import logging
 import os
 
-from clayde.config import STATE_FILE
+from clayde.config import get_settings
 
 log = logging.getLogger("clayde.state")
 
 
 def load_state():
-    if os.path.exists(STATE_FILE):
-        with open(STATE_FILE) as f:
+    state_file = get_settings().state_file
+    if os.path.exists(state_file):
+        with open(state_file) as f:
             return json.load(f)
     return {"issues": {}}
 
 
 def save_state(state):
-    with open(STATE_FILE, "w") as f:
+    with open(get_settings().state_file, "w") as f:
         json.dump(state, f, indent=2)
 
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,8 +1,7 @@
 """Tests for clayde.claude."""
 
-import os
-import subprocess
-from unittest.mock import MagicMock, mock_open, patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,6 +12,12 @@ from clayde.claude import (
     invoke_claude,
     is_claude_available,
 )
+
+
+def _mock_settings(dir_path):
+    s = MagicMock()
+    s.dir = Path(dir_path)
+    return s
 
 
 class TestIsLimitError:
@@ -61,8 +66,7 @@ class TestMakeEnv:
 
 
 class TestInvokeClaude:
-    def test_success(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("clayde.claude.CLAYDE_DIR", str(tmp_path))
+    def test_success(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity text")
 
         mock_result = MagicMock()
@@ -70,17 +74,17 @@ class TestInvokeClaude:
         mock_result.stdout = "plan output"
         mock_result.stderr = ""
 
-        with patch("clayde.claude.subprocess.run", return_value=mock_result) as mock_run:
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(tmp_path)), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result) as mock_run:
             result = invoke_claude("test prompt", "/some/repo")
 
         assert result == "plan output"
         mock_run.assert_called_once()
         args = mock_run.call_args
-        assert args[0][0][2] == "test prompt"  # -p argument
+        assert args[0][0][2] == "test prompt"
         assert args[1]["cwd"] == "/some/repo"
 
-    def test_nonzero_exit_without_limit(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("clayde.claude.CLAYDE_DIR", str(tmp_path))
+    def test_nonzero_exit_without_limit(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
 
         mock_result = MagicMock()
@@ -88,13 +92,13 @@ class TestInvokeClaude:
         mock_result.stdout = "partial output"
         mock_result.stderr = "some error"
 
-        with patch("clayde.claude.subprocess.run", return_value=mock_result):
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(tmp_path)), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
             result = invoke_claude("prompt", "/repo")
 
         assert result == "partial output"
 
-    def test_nonzero_exit_with_limit_raises(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("clayde.claude.CLAYDE_DIR", str(tmp_path))
+    def test_nonzero_exit_with_limit_raises(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
 
         mock_result = MagicMock()
@@ -102,12 +106,12 @@ class TestInvokeClaude:
         mock_result.stdout = ""
         mock_result.stderr = "You have hit your usage limit"
 
-        with patch("clayde.claude.subprocess.run", return_value=mock_result):
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(tmp_path)), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
             with pytest.raises(UsageLimitError):
                 invoke_claude("prompt", "/repo")
 
-    def test_exit_zero_with_limit_in_stdout_raises(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("clayde.claude.CLAYDE_DIR", str(tmp_path))
+    def test_exit_zero_with_limit_in_stdout_raises(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
 
         mock_result = MagicMock()
@@ -115,12 +119,12 @@ class TestInvokeClaude:
         mock_result.stdout = "Some output... you've reached the limit"
         mock_result.stderr = ""
 
-        with patch("clayde.claude.subprocess.run", return_value=mock_result):
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(tmp_path)), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
             with pytest.raises(UsageLimitError):
                 invoke_claude("prompt", "/repo")
 
-    def test_returns_empty_string_on_none_stdout(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("clayde.claude.CLAYDE_DIR", str(tmp_path))
+    def test_returns_empty_string_on_none_stdout(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
 
         mock_result = MagicMock()
@@ -128,7 +132,8 @@ class TestInvokeClaude:
         mock_result.stdout = None
         mock_result.stderr = None
 
-        with patch("clayde.claude.subprocess.run", return_value=mock_result):
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(tmp_path)), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
             result = invoke_claude("prompt", "/repo")
         assert result == ""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,74 +1,115 @@
 """Tests for clayde.config."""
 
 import logging
-import os
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
-from clayde import config
+from clayde.config import Settings, _reset_settings, get_settings, setup_logging
 
 
-class TestLoadConfig:
-    def test_parses_key_value_pairs(self, monkeypatch):
-        fake_env = "KEY1=value1\nKEY2=value2\n"
-        monkeypatch.setattr(config, "WHITELISTED_USERS", [])
-        with patch("builtins.open", mock_open(read_data=fake_env)):
-            result = config.load_config()
-        assert result["KEY1"] == "value1"
-        assert result["KEY2"] == "value2"
+class TestSettings:
+    def test_loads_from_env_vars(self, monkeypatch):
+        monkeypatch.setenv("CLAYDE_GITHUB_TOKEN", "tok123")
+        monkeypatch.setenv("CLAYDE_ENABLED", "true")
+        monkeypatch.setenv("CLAYDE_WHITELISTED_USERS_RAW", "alice,bob")
+        s = Settings(_env_file=None)
+        assert s.github_token == "tok123"
+        assert s.enabled is True
+        assert s.whitelisted_users == ["alice", "bob"]
 
-    def test_skips_comments_and_blank_lines(self, monkeypatch):
-        fake_env = "# comment\n\n  \nKEY=val\n"
-        monkeypatch.setattr(config, "WHITELISTED_USERS", [])
-        with patch("builtins.open", mock_open(read_data=fake_env)):
-            result = config.load_config()
-        assert result == {"KEY": "val"}
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv("CLAYDE_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("CLAYDE_ENABLED", raising=False)
+        monkeypatch.delenv("CLAYDE_WHITELISTED_USERS_RAW", raising=False)
+        monkeypatch.delenv("CLAYDE_DIR", raising=False)
+        s = Settings(_env_file=None)
+        assert s.github_token == ""
+        assert s.enabled is False
+        assert s.github_username == "ClaydeCode"
+        assert s.whitelisted_users == ["max-tet", "ClaydeCode"]
 
-    def test_populates_whitelisted_users(self, monkeypatch):
-        fake_env = "WHITELISTED_USERS=alice,bob, charlie \n"
-        monkeypatch.setattr(config, "WHITELISTED_USERS", [])
-        with patch("builtins.open", mock_open(read_data=fake_env)):
-            config.load_config()
-        assert config.WHITELISTED_USERS == ["alice", "bob", "charlie"]
+    def test_loads_from_env_file(self, tmp_path, monkeypatch):
+        env_file = tmp_path / "config.env"
+        env_file.write_text("CLAYDE_GITHUB_TOKEN=file-tok\nCLAYDE_ENABLED=true\n")
+        monkeypatch.delenv("CLAYDE_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("CLAYDE_ENABLED", raising=False)
+        s = Settings(_env_file=str(env_file))
+        assert s.github_token == "file-tok"
+        assert s.enabled is True
 
-    def test_default_whitelisted_users_when_missing(self, monkeypatch):
-        fake_env = "SOME_KEY=val\n"
-        monkeypatch.setattr(config, "WHITELISTED_USERS", [])
-        with patch("builtins.open", mock_open(read_data=fake_env)):
-            config.load_config()
-        assert config.WHITELISTED_USERS == ["max-tet", "ClaydeCode"]
+    def test_comma_separated_whitelisted_users(self, monkeypatch):
+        monkeypatch.setenv("CLAYDE_WHITELISTED_USERS_RAW", "alice, bob , charlie")
+        s = Settings(_env_file=None)
+        assert s.whitelisted_users == ["alice", "bob", "charlie"]
 
-    def test_value_with_equals_sign(self, monkeypatch):
-        fake_env = "TOKEN=abc=def=ghi\n"
-        monkeypatch.setattr(config, "WHITELISTED_USERS", [])
-        with patch("builtins.open", mock_open(read_data=fake_env)):
-            result = config.load_config()
-        assert result["TOKEN"] == "abc=def=ghi"
+    def test_derived_paths(self, monkeypatch):
+        monkeypatch.setenv("CLAYDE_DIR", "/custom/dir")
+        s = Settings(_env_file=None)
+        assert s.state_file == "/custom/dir/state.json"
+        assert s.log_file == "/custom/dir/logs/agent.log"
+        assert s.repos_dir == "/custom/dir/repos"
+
+    def test_value_with_equals_sign(self, tmp_path, monkeypatch):
+        env_file = tmp_path / "config.env"
+        env_file.write_text("CLAYDE_GITHUB_TOKEN=abc=def=ghi\n")
+        monkeypatch.delenv("CLAYDE_GITHUB_TOKEN", raising=False)
+        s = Settings(_env_file=str(env_file))
+        assert s.github_token == "abc=def=ghi"
+
+
+class TestGetSettings:
+    def test_returns_singleton(self, monkeypatch):
+        _reset_settings()
+        monkeypatch.setenv("CLAYDE_GITHUB_TOKEN", "tok")
+        with patch("clayde.config.Settings", wraps=Settings) as mock_cls:
+            mock_cls.side_effect = lambda **kw: Settings(_env_file=None)
+            s1 = get_settings()
+            s2 = get_settings()
+        assert s1 is s2
+        _reset_settings()
+
+    def test_reset_clears_cache(self, monkeypatch):
+        _reset_settings()
+        monkeypatch.setenv("CLAYDE_GITHUB_TOKEN", "tok1")
+        with patch("clayde.config.Settings", side_effect=lambda **kw: Settings(_env_file=None)):
+            s1 = get_settings()
+        _reset_settings()
+        monkeypatch.setenv("CLAYDE_GITHUB_TOKEN", "tok2")
+        with patch("clayde.config.Settings", side_effect=lambda **kw: Settings(_env_file=None)):
+            s2 = get_settings()
+        assert s1 is not s2
+        _reset_settings()
 
 
 class TestGetGithubClient:
-    def test_uses_gh_token_from_env(self, monkeypatch):
-        monkeypatch.setenv("GH_TOKEN", "test-token-123")
-        with patch("clayde.config.Github") as mock_gh, \
-             patch("clayde.config.Auth.Token") as mock_token:
-            mock_token.return_value = "auth-obj"
-            config.get_github_client()
-            mock_token.assert_called_once_with("test-token-123")
-            mock_gh.assert_called_once_with(auth="auth-obj")
+    def test_uses_token_from_settings(self, monkeypatch):
+        _reset_settings()
+        monkeypatch.setenv("CLAYDE_GITHUB_TOKEN", "test-token-123")
+        with patch("clayde.config.Settings", side_effect=lambda **kw: Settings(_env_file=None)):
+            from clayde.config import get_github_client
+            with patch("clayde.config.Github") as mock_gh, \
+                 patch("clayde.config.Auth.Token") as mock_token:
+                mock_token.return_value = "auth-obj"
+                get_github_client()
+                mock_token.assert_called_once_with("test-token-123")
+                mock_gh.assert_called_once_with(auth="auth-obj")
+        _reset_settings()
 
 
 class TestSetupLogging:
     def test_creates_handler_and_configures_logger(self, tmp_path, monkeypatch):
+        _reset_settings()
+        monkeypatch.setenv("CLAYDE_DIR", str(tmp_path))
+        with patch("clayde.config.Settings", side_effect=lambda **kw: Settings(_env_file=None)):
+            setup_logging()
         log_file = str(tmp_path / "logs" / "agent.log")
-        monkeypatch.setattr(config, "LOG_FILE", log_file)
-        config.setup_logging()
         logger = logging.getLogger("clayde")
         assert logger.level == logging.INFO
         assert any(
             isinstance(h, logging.FileHandler) and h.baseFilename == log_file
             for h in logger.handlers
         )
-        # Clean up handler to avoid affecting other tests
         for h in logger.handlers[:]:
             if isinstance(h, logging.FileHandler) and h.baseFilename == log_file:
                 logger.removeHandler(h)
                 h.close()
+        _reset_settings()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,19 +1,25 @@
 """Tests for clayde.git."""
 
 import os
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import clayde.git as git_mod
 
 
+def _mock_settings(repos_dir):
+    s = MagicMock()
+    s.repos_dir = repos_dir
+    return s
+
+
 class TestEnsureRepo:
-    def test_clones_when_no_git_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(git_mod, "REPOS_DIR", str(tmp_path))
+    def test_clones_when_no_git_dir(self, tmp_path):
         repo_path = os.path.join(str(tmp_path), "alice__myrepo")
 
-        with patch("clayde.git.subprocess.run") as mock_run:
+        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+             patch("clayde.git.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             result = git_mod.ensure_repo("alice", "myrepo", "main")
 
@@ -23,12 +29,12 @@ class TestEnsureRepo:
             capture_output=True, text=True,
         )
 
-    def test_updates_when_git_dir_exists(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(git_mod, "REPOS_DIR", str(tmp_path))
+    def test_updates_when_git_dir_exists(self, tmp_path):
         repo_path = os.path.join(str(tmp_path), "alice__myrepo")
         os.makedirs(os.path.join(repo_path, ".git"))
 
-        with patch("clayde.git.subprocess.run") as mock_run:
+        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+             patch("clayde.git.subprocess.run") as mock_run:
             result = git_mod.ensure_repo("alice", "myrepo", "main")
 
         assert result == repo_path
@@ -40,10 +46,9 @@ class TestEnsureRepo:
             ["git", "pull"], cwd=repo_path, capture_output=True,
         )
 
-    def test_clone_failure_raises(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(git_mod, "REPOS_DIR", str(tmp_path))
-
-        with patch("clayde.git.subprocess.run") as mock_run:
+    def test_clone_failure_raises(self, tmp_path):
+        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+             patch("clayde.git.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="fatal: not found")
             with pytest.raises(RuntimeError, match="Clone failed"):
                 git_mod.ensure_repo("alice", "myrepo", "main")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -12,16 +12,22 @@ from clayde.orchestrator import (
 )
 
 
+def _mock_settings(enabled=False, github_token="tok"):
+    s = MagicMock()
+    s.enabled = enabled
+    s.github_token = github_token
+    return s
+
+
 class TestMain:
     def test_exits_when_disabled(self):
-        with patch("clayde.orchestrator.load_config", return_value={"CLAYDE_ENABLED": "false"}):
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=False)):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 0
 
     def test_returns_when_claude_unavailable(self):
-        config = {"CLAYDE_ENABLED": "true", "GITHUB_TOKEN": "tok"}
-        with patch("clayde.orchestrator.load_config", return_value=config), \
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=True)), \
              patch("clayde.orchestrator.setup_logging"), \
              patch("clayde.orchestrator.is_claude_available", return_value=False), \
              patch("clayde.orchestrator.get_github_client") as mock_gc:
@@ -29,36 +35,32 @@ class TestMain:
             mock_gc.assert_not_called()
 
     def test_returns_when_no_assigned_issues(self):
-        config = {"CLAYDE_ENABLED": "true", "GITHUB_TOKEN": "tok"}
-        with patch("clayde.orchestrator.load_config", return_value=config), \
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=True)), \
              patch("clayde.orchestrator.setup_logging"), \
              patch("clayde.orchestrator.is_claude_available", return_value=True), \
              patch("clayde.orchestrator.get_github_client"), \
              patch("clayde.orchestrator.get_assigned_issues", return_value=[]), \
              patch("clayde.orchestrator.load_state", return_value={"issues": {}}):
-            main()  # Should not raise
+            main()
 
     def test_dispatches_new_issue(self):
-        config = {"CLAYDE_ENABLED": "true", "GITHUB_TOKEN": "tok"}
         issue = MagicMock()
         issue.html_url = "https://github.com/o/r/issues/1"
-        with patch("clayde.orchestrator.load_config", return_value=config), \
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=True)), \
              patch("clayde.orchestrator.setup_logging"), \
              patch("clayde.orchestrator.is_claude_available", return_value=True), \
-             patch("clayde.orchestrator.get_github_client") as mock_gc, \
+             patch("clayde.orchestrator.get_github_client"), \
              patch("clayde.orchestrator.get_assigned_issues", return_value=[issue]), \
              patch("clayde.orchestrator.load_state", return_value={"issues": {}}), \
              patch("clayde.orchestrator._handle_new_issue") as mock_handle:
-            # Patch _handle_new_issue at module level
             main()
             mock_handle.assert_called_once()
 
     def test_skips_done_issues(self):
-        config = {"CLAYDE_ENABLED": "true", "GITHUB_TOKEN": "tok"}
         issue = MagicMock()
         issue.html_url = "url1"
         state = {"issues": {"url1": {"status": "done"}}}
-        with patch("clayde.orchestrator.load_config", return_value=config), \
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=True)), \
              patch("clayde.orchestrator.setup_logging"), \
              patch("clayde.orchestrator.is_claude_available", return_value=True), \
              patch("clayde.orchestrator.get_github_client"), \

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,8 +1,7 @@
 """Tests for clayde.safety."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-import clayde.safety as safety_mod
 from clayde.safety import _has_whitelisted_reaction, is_issue_authorized, is_plan_approved
 
 
@@ -13,69 +12,75 @@ def _make_reaction(content, login):
     return r
 
 
+def _mock_settings(users):
+    s = MagicMock()
+    s.whitelisted_users = users
+    return s
+
+
 class TestIsIssueAuthorized:
-    def test_whitelisted_author(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_whitelisted_author(self):
         issue = MagicMock()
         issue.user.login = "alice"
-        assert is_issue_authorized(issue) is True
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_issue_authorized(issue) is True
 
-    def test_non_whitelisted_author_with_thumbsup(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_non_whitelisted_author_with_thumbsup(self):
         issue = MagicMock()
         issue.user.login = "bob"
         issue.get_reactions.return_value = [_make_reaction("+1", "alice")]
-        assert is_issue_authorized(issue) is True
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_issue_authorized(issue) is True
 
-    def test_non_whitelisted_author_without_approval(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_non_whitelisted_author_without_approval(self):
         issue = MagicMock()
         issue.user.login = "bob"
         issue.get_reactions.return_value = [_make_reaction("+1", "charlie")]
-        assert is_issue_authorized(issue) is False
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_issue_authorized(issue) is False
 
-    def test_no_reactions(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_no_reactions(self):
         issue = MagicMock()
         issue.user.login = "bob"
         issue.get_reactions.return_value = []
-        assert is_issue_authorized(issue) is False
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_issue_authorized(issue) is False
 
 
 class TestIsPlanApproved:
-    def test_approved_with_thumbsup(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_approved_with_thumbsup(self):
         g = MagicMock()
         comment = MagicMock()
         comment.get_reactions.return_value = [_make_reaction("+1", "alice")]
         g.get_repo.return_value.get_issue.return_value.get_comment.return_value = comment
-        assert is_plan_approved(g, "owner", "repo", 1, 100) is True
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_plan_approved(g, "owner", "repo", 1, 100) is True
 
-    def test_not_approved_wrong_reaction(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_not_approved_wrong_reaction(self):
         g = MagicMock()
         comment = MagicMock()
         comment.get_reactions.return_value = [_make_reaction("heart", "alice")]
         g.get_repo.return_value.get_issue.return_value.get_comment.return_value = comment
-        assert is_plan_approved(g, "owner", "repo", 1, 100) is False
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert is_plan_approved(g, "owner", "repo", 1, 100) is False
 
 
 class TestHasWhitelistedReaction:
-    def test_matching_reaction(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_matching_reaction(self):
         reactions = [_make_reaction("+1", "alice")]
-        assert _has_whitelisted_reaction(reactions) is True
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert _has_whitelisted_reaction(reactions) is True
 
-    def test_wrong_content(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_wrong_content(self):
         reactions = [_make_reaction("-1", "alice")]
-        assert _has_whitelisted_reaction(reactions) is False
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert _has_whitelisted_reaction(reactions) is False
 
-    def test_wrong_user(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
+    def test_wrong_user(self):
         reactions = [_make_reaction("+1", "bob")]
-        assert _has_whitelisted_reaction(reactions) is False
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert _has_whitelisted_reaction(reactions) is False
 
-    def test_empty_reactions(self, monkeypatch):
-        monkeypatch.setattr(safety_mod, "WHITELISTED_USERS", ["alice"])
-        assert _has_whitelisted_reaction([]) is False
+    def test_empty_reactions(self):
+        with patch("clayde.safety.get_settings", return_value=_mock_settings(["alice"])):
+            assert _has_whitelisted_reaction([]) is False

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,61 +1,69 @@
 """Tests for clayde.state."""
 
 import json
+from unittest.mock import MagicMock, patch
 
 import clayde.state as state_mod
 
 
-class TestLoadState:
-    def test_returns_empty_when_file_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(tmp_path / "nonexistent.json"))
-        assert state_mod.load_state() == {"issues": {}}
+def _mock_settings(state_file):
+    s = MagicMock()
+    s.state_file = state_file
+    return s
 
-    def test_loads_existing_state(self, tmp_path, monkeypatch):
+
+class TestLoadState:
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        sf = str(tmp_path / "nonexistent.json")
+        with patch("clayde.state.get_settings", return_value=_mock_settings(sf)):
+            assert state_mod.load_state() == {"issues": {}}
+
+    def test_loads_existing_state(self, tmp_path):
         sf = tmp_path / "state.json"
         data = {"issues": {"url1": {"status": "done"}}}
         sf.write_text(json.dumps(data))
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        assert state_mod.load_state() == data
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            assert state_mod.load_state() == data
 
 
 class TestSaveState:
-    def test_writes_json(self, tmp_path, monkeypatch):
+    def test_writes_json(self, tmp_path):
         sf = tmp_path / "state.json"
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        data = {"issues": {"url": {"status": "planning"}}}
-        state_mod.save_state(data)
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            data = {"issues": {"url": {"status": "planning"}}}
+            state_mod.save_state(data)
         assert json.loads(sf.read_text()) == data
 
 
 class TestGetIssueState:
-    def test_returns_empty_for_unknown_url(self, tmp_path, monkeypatch):
+    def test_returns_empty_for_unknown_url(self, tmp_path):
         sf = tmp_path / "state.json"
         sf.write_text(json.dumps({"issues": {}}))
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        assert state_mod.get_issue_state("unknown") == {}
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            assert state_mod.get_issue_state("unknown") == {}
 
-    def test_returns_entry_for_known_url(self, tmp_path, monkeypatch):
+    def test_returns_entry_for_known_url(self, tmp_path):
         sf = tmp_path / "state.json"
         entry = {"status": "done", "pr_url": "https://example.com"}
         sf.write_text(json.dumps({"issues": {"url1": entry}}))
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        assert state_mod.get_issue_state("url1") == entry
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            assert state_mod.get_issue_state("url1") == entry
 
 
 class TestUpdateIssueState:
-    def test_creates_new_entry(self, tmp_path, monkeypatch):
+    def test_creates_new_entry(self, tmp_path):
         sf = tmp_path / "state.json"
         sf.write_text(json.dumps({"issues": {}}))
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        state_mod.update_issue_state("url1", {"status": "planning", "owner": "o"})
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            state_mod.update_issue_state("url1", {"status": "planning", "owner": "o"})
         result = json.loads(sf.read_text())
         assert result["issues"]["url1"]["status"] == "planning"
         assert result["issues"]["url1"]["owner"] == "o"
 
-    def test_merges_updates(self, tmp_path, monkeypatch):
+    def test_merges_updates(self, tmp_path):
         sf = tmp_path / "state.json"
         sf.write_text(json.dumps({"issues": {"url1": {"status": "planning", "owner": "o"}}}))
-        monkeypatch.setattr(state_mod, "STATE_FILE", str(sf))
-        state_mod.update_issue_state("url1", {"status": "done", "pr_url": "pr"})
+        with patch("clayde.state.get_settings", return_value=_mock_settings(str(sf))):
+            state_mod.update_issue_state("url1", {"status": "done", "pr_url": "pr"})
         result = json.loads(sf.read_text())
         assert result["issues"]["url1"] == {"status": "done", "owner": "o", "pr_url": "pr"}

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -131,6 +140,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
+    { name = "pydantic-settings" },
     { name = "pygithub" },
 ]
 
@@ -142,6 +152,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pygithub", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
@@ -330,6 +341,106 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygithub"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -420,6 +531,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -441,6 +561,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #11

## Summary

- Added `pydantic-settings` dependency and replaced the hand-rolled `config.env` parser with a `Settings(BaseSettings)` model
- All settings use the `CLAYDE_` env prefix (e.g. `CLAYDE_GITHUB_TOKEN`, `CLAYDE_ENABLED`)
- Removed the mutable `WHITELISTED_USERS` list — replaced with an immutable `computed_field` property parsed from a comma-separated string
- Updated all consumer modules (`orchestrator`, `state`, `git`, `claude`, `safety`) to use `get_settings()` singleton instead of module-level constants
- Added `config.env.template` as a checked-in reference file
- Updated all tests to mock `get_settings()` instead of monkeypatching module-level constants

## Migration required

After merging, update `/home/ubuntu/clayde/config.env` to use prefixed keys:

```
CLAYDE_GITHUB_TOKEN=ghp_...
CLAYDE_GITHUB_USERNAME=ClaydeCode
CLAYDE_ENABLED=true
CLAYDE_WHITELISTED_USERS_RAW=max-tet,ClaydeCode
```

## Test plan

- [x] All 100 existing tests pass
- [ ] Verify env var override works (`CLAYDE_ENABLED=false` overrides file value)
- [ ] Update live `config.env` after merge and verify `uv run clayde` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)