### PR TITLE
Add OpenTelemetry tracing instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Clayde — autonomous GitHub issue agent"
 requires-python = ">=3.12"
 dependencies = [
     "jinja2>=3.1.6",
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20",
     "pydantic-settings>=2.0",
     "PyGitHub>=2.5.0",
 ]

--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 
 from clayde.config import get_settings
+from clayde.telemetry import get_tracer
 
 log = logging.getLogger("clayde.claude")
 
@@ -40,35 +41,53 @@ def invoke_claude(prompt, repo_path):
 
     Raises UsageLimitError if the Claude CLI reports a usage/rate limit.
     """
-    identity = open(os.path.join(str(get_settings().dir), "CLAUDE.md")).read()
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.invoke_claude") as span:
+        identity = open(os.path.join(str(get_settings().dir), "CLAUDE.md")).read()
 
-    result = subprocess.run(
-        [
-            os.path.expanduser("~/.local/bin/claude"), "-p", prompt,
-            "--append-system-prompt", identity,
-            "--dangerously-skip-permissions",
-        ],
-        cwd=repo_path,
-        env=_make_env(),
-        text=True,
-        capture_output=True,
-        timeout=1800,
-    )
+        try:
+            result = subprocess.run(
+                [
+                    os.path.expanduser("~/.local/bin/claude"), "-p", prompt,
+                    "--append-system-prompt", identity,
+                    "--dangerously-skip-permissions",
+                ],
+                cwd=repo_path,
+                env=_make_env(),
+                text=True,
+                capture_output=True,
+                timeout=1800,
+            )
+        except subprocess.TimeoutExpired as e:
+            span.set_attribute("claude.timeout", True)
+            span.record_exception(e)
+            raise
 
-    combined = (result.stdout or "") + (result.stderr or "")
+        span.set_attribute("claude.timeout", False)
+        span.set_attribute("claude.exit_code", result.returncode)
+        span.set_attribute("claude.output_length", len(result.stdout or ""))
 
-    if result.returncode != 0:
-        log.error("Claude exited with code %d", result.returncode)
-        if result.stderr:
-            log.error("stderr: %s", result.stderr[:500])
-        if _is_limit_error(combined):
-            raise UsageLimitError("Claude usage limit hit")
+        combined = (result.stdout or "") + (result.stderr or "")
 
-    # Claude sometimes exits 0 but embeds a limit message in stdout
-    if _is_limit_error(result.stdout or ""):
-        raise UsageLimitError("Claude usage limit hit (exit 0 but limit message in stdout)")
+        if result.returncode != 0:
+            log.error("Claude exited with code %d", result.returncode)
+            if result.stderr:
+                log.error("stderr: %s", result.stderr[:500])
+            if _is_limit_error(combined):
+                span.set_attribute("claude.usage_limit", True)
+                exc = UsageLimitError("Claude usage limit hit")
+                span.record_exception(exc)
+                raise exc
 
-    return result.stdout or ""
+        # Claude sometimes exits 0 but embeds a limit message in stdout
+        if _is_limit_error(result.stdout or ""):
+            span.set_attribute("claude.usage_limit", True)
+            exc = UsageLimitError("Claude usage limit hit (exit 0 but limit message in stdout)")
+            span.record_exception(exc)
+            raise exc
+
+        span.set_attribute("claude.usage_limit", False)
+        return result.stdout or ""
 
 
 def is_claude_available():
@@ -78,20 +97,27 @@ def is_claude_available():
     detected. Any other error (CLI not found, unexpected failure) is treated
     as available so we don't suppress real work on spurious pre-check errors.
     """
-    try:
-        result = subprocess.run(
-            [os.path.expanduser("~/.local/bin/claude"), "-p", "respond with: OK"],
-            env=_make_env(),
-            text=True,
-            capture_output=True,
-            timeout=60,
-        )
-        combined = (result.stdout or "") + (result.stderr or "")
-        if result.returncode != 0 and _is_limit_error(combined):
-            return False
-        if _is_limit_error(result.stdout or ""):
-            return False
-        return True
-    except Exception as exc:
-        log.warning("Claude availability pre-check raised %s — assuming available", exc)
-        return True
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.claude_available_check") as span:
+        try:
+            result = subprocess.run(
+                [os.path.expanduser("~/.local/bin/claude"), "-p", "respond with: OK"],
+                env=_make_env(),
+                text=True,
+                capture_output=True,
+                timeout=60,
+            )
+            combined = (result.stdout or "") + (result.stderr or "")
+            if result.returncode != 0 and _is_limit_error(combined):
+                span.set_attribute("claude.available", False)
+                return False
+            if _is_limit_error(result.stdout or ""):
+                span.set_attribute("claude.available", False)
+                return False
+            span.set_attribute("claude.available", True)
+            return True
+        except Exception as exc:
+            log.warning("Claude availability pre-check raised %s — assuming available", exc)
+            span.set_attribute("claude.available", True)
+            span.set_attribute("claude.check_error", str(exc))
+            return True

--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -9,57 +9,88 @@ import logging
 import os
 import sys
 
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
 from clayde.claude import is_claude_available
 from clayde.config import get_github_client, get_settings, setup_logging
 from clayde.github import get_assigned_issues
 from clayde.safety import is_issue_authorized, is_plan_approved
 from clayde.state import load_state, update_issue_state
 from clayde.tasks import implement, plan
+from clayde.telemetry import get_tracer, init_tracer
 
 log = logging.getLogger("clayde.orchestrator")
 
 
 def _handle_new_issue(g, issue, url: str) -> None:
-    if not is_issue_authorized(issue):
-        log.info("Skipping issue %s — not created by or approved by a whitelisted user", url)
-        return
-    log.info("New issue: %s — starting plan phase", url)
-    try:
-        plan.run(url)
-    except Exception as e:
-        log.error("ERROR in plan for %s: %s", url, e)
-        update_issue_state(url, {"status": "failed"})
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.handle_issue", attributes={"issue.url": url, "issue.handler": "new"}) as span:
+        if not is_issue_authorized(issue):
+            log.info("Skipping issue %s — not created by or approved by a whitelisted user", url)
+            span.set_attribute("issue.skipped", True)
+            span.set_attribute("issue.skip_reason", "unauthorized")
+            return
+        log.info("New issue: %s — starting plan phase", url)
+        try:
+            plan.run(url)
+            span.set_attribute("issue.failed", False)
+        except Exception as e:
+            log.error("ERROR in plan for %s: %s", url, e)
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            span.set_attribute("issue.failed", True)
+            update_issue_state(url, {"status": "failed"})
 
 
 def _handle_awaiting_approval(g, url: str, entry: dict) -> None:
-    owner = entry["owner"]
-    repo = entry["repo"]
-    number = entry["number"]
-    comment_id = entry["plan_comment_id"]
-    if not is_plan_approved(g, owner, repo, number, comment_id):
-        log.info("Issue %s awaiting approval", url)
-        return
-    log.info("Plan approved: %s — starting implementation", url)
-    try:
-        implement.run(url)
-    except Exception as e:
-        log.error("ERROR in implement for %s: %s", url, e)
-        update_issue_state(url, {"status": "failed"})
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.handle_issue", attributes={"issue.url": url, "issue.handler": "awaiting_approval"}) as span:
+        owner = entry["owner"]
+        repo = entry["repo"]
+        number = entry["number"]
+        comment_id = entry["plan_comment_id"]
+        span.set_attribute("issue.number", number)
+        span.set_attribute("issue.owner", owner)
+        span.set_attribute("issue.repo", repo)
+        if not is_plan_approved(g, owner, repo, number, comment_id):
+            log.info("Issue %s awaiting approval", url)
+            span.set_attribute("issue.skipped", True)
+            span.set_attribute("issue.skip_reason", "not_approved")
+            return
+        log.info("Plan approved: %s — starting implementation", url)
+        try:
+            implement.run(url)
+            span.set_attribute("issue.failed", False)
+        except Exception as e:
+            log.error("ERROR in implement for %s: %s", url, e)
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            span.set_attribute("issue.failed", True)
+            update_issue_state(url, {"status": "failed"})
 
 
 def _handle_interrupted(url: str, entry: dict) -> None:
+    tracer = get_tracer()
     phase = entry.get("interrupted_phase")
-    log.info("Retrying interrupted issue %s (phase: %s)", url, phase)
-    task = {"planning": plan.run, "implementing": implement.run}.get(phase)
-    if task is None:
-        log.warning("Unknown interrupted_phase '%s' for %s — skipping", phase, url)
-        return
-    try:
-        task(url)
-    except Exception as e:
-        log.error("ERROR retrying interrupted issue %s: %s", url, e)
-        # Stay in interrupted state so we keep retrying.
-        update_issue_state(url, {"status": "interrupted"})
+    with tracer.start_as_current_span("clayde.handle_issue", attributes={"issue.url": url, "issue.handler": "interrupted", "issue.interrupted_phase": phase or "unknown"}) as span:
+        log.info("Retrying interrupted issue %s (phase: %s)", url, phase)
+        task = {"planning": plan.run, "implementing": implement.run}.get(phase)
+        if task is None:
+            log.warning("Unknown interrupted_phase '%s' for %s — skipping", phase, url)
+            span.set_attribute("issue.skipped", True)
+            span.set_attribute("issue.skip_reason", "unknown_phase")
+            return
+        try:
+            task(url)
+            span.set_attribute("issue.failed", False)
+        except Exception as e:
+            log.error("ERROR retrying interrupted issue %s: %s", url, e)
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            span.set_attribute("issue.failed", True)
+            # Stay in interrupted state so we keep retrying.
+            update_issue_state(url, {"status": "interrupted"})
 
 
 def main():
@@ -71,33 +102,48 @@ def main():
     os.environ["GH_TOKEN"] = settings.github_token
 
     setup_logging()
+    provider = init_tracer()
+    tracer = get_tracer()
 
-    if not is_claude_available():
-        log.warning("Claude usage limit hit — skipping all work this cycle")
-        return
+    with tracer.start_as_current_span("clayde.tick") as tick_span:
+        if not is_claude_available():
+            log.warning("Claude usage limit hit — skipping all work this cycle")
+            tick_span.set_attribute("claude.available", False)
+            provider.force_flush()
+            return
 
-    g = get_github_client()
-    assigned = get_assigned_issues(g)
-    state = load_state()
-    issues_state = state.get("issues", {})
+        tick_span.set_attribute("claude.available", True)
+        g = get_github_client()
+        assigned = get_assigned_issues(g)
+        state = load_state()
+        issues_state = state.get("issues", {})
 
-    if not assigned:
-        log.info("No assigned issues. Going back to sleep.")
-        return
+        tick_span.set_attribute("issues.assigned_count", len(assigned))
 
-    for issue in assigned:
-        url = issue.html_url
-        entry = issues_state.get(url, {})
-        status = entry.get("status")
+        if not assigned:
+            log.info("No assigned issues. Going back to sleep.")
+            provider.force_flush()
+            return
 
-        if status in ("done", "planning", "implementing"):
-            continue
+        processed = 0
+        for issue in assigned:
+            url = issue.html_url
+            entry = issues_state.get(url, {})
+            status = entry.get("status")
 
-        if status is None:
-            _handle_new_issue(g, issue, url)
-        elif status == "awaiting_approval":
-            _handle_awaiting_approval(g, url, entry)
-        elif status == "interrupted":
-            _handle_interrupted(url, entry)
-        elif status == "failed":
-            log.info("Skipping failed issue: %s (clear state to retry)", url)
+            if status in ("done", "planning", "implementing"):
+                continue
+
+            processed += 1
+            if status is None:
+                _handle_new_issue(g, issue, url)
+            elif status == "awaiting_approval":
+                _handle_awaiting_approval(g, url, entry)
+            elif status == "interrupted":
+                _handle_interrupted(url, entry)
+            elif status == "failed":
+                log.info("Skipping failed issue: %s (clear state to retry)", url)
+
+        tick_span.set_attribute("issues.processed", processed)
+
+    provider.force_flush()

--- a/src/clayde/state.py
+++ b/src/clayde/state.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 
+from opentelemetry import trace
+
 from clayde.config import get_settings
 
 log = logging.getLogger("clayde.state")
@@ -29,5 +31,16 @@ def get_issue_state(issue_url):
 def update_issue_state(issue_url, updates):
     state = load_state()
     entry = state["issues"].setdefault(issue_url, {})
+    old_status = entry.get("status")
     entry.update(updates)
+    new_status = entry.get("status")
     save_state(state)
+
+    if old_status != new_status:
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.add_event("state_transition", attributes={
+                "issue.url": issue_url,
+                "old_status": old_status or "(none)",
+                "new_status": new_status or "(none)",
+            })

--- a/src/clayde/tasks/implement.py
+++ b/src/clayde/tasks/implement.py
@@ -20,6 +20,7 @@ from clayde.github import (
     post_comment,
 )
 from clayde.state import get_issue_state, update_issue_state
+from clayde.telemetry import get_tracer
 
 log = logging.getLogger("clayde.tasks.implement")
 
@@ -27,60 +28,74 @@ _PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
 def run(issue_url: str) -> None:
-    g = get_github_client()
-    owner, repo, number = parse_issue_url(issue_url)
-    issue_state = get_issue_state(issue_url)
-    plan_comment_id = issue_state["plan_comment_id"]
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.task.implement") as span:
+        g = get_github_client()
+        owner, repo, number = parse_issue_url(issue_url)
+        issue_state = get_issue_state(issue_url)
+        plan_comment_id = issue_state["plan_comment_id"]
+        span.set_attribute("issue.number", number)
+        span.set_attribute("issue.owner", owner)
+        span.set_attribute("issue.repo", repo)
 
-    # If resuming from an interrupted implementation, check for an existing PR.
-    if issue_state.get("status") == "interrupted":
-        branch_name = issue_state.get("branch_name", f"clayde/issue-{number}")
-        existing_pr = find_open_pr(g, owner, repo, branch_name)
-        if existing_pr:
-            log.info("Resuming interrupted #%d — found existing PR %s", number, existing_pr)
-            post_comment(g, owner, repo, number, f"Implementation complete — PR opened: {existing_pr}")
-            update_issue_state(issue_url, {"status": "done", "pr_url": existing_pr})
+        resumed = issue_state.get("status") == "interrupted"
+        span.set_attribute("implement.resumed_from_interrupted", resumed)
+
+        # If resuming from an interrupted implementation, check for an existing PR.
+        if resumed:
+            branch_name = issue_state.get("branch_name", f"clayde/issue-{number}")
+            existing_pr = find_open_pr(g, owner, repo, branch_name)
+            if existing_pr:
+                log.info("Resuming interrupted #%d — found existing PR %s", number, existing_pr)
+                post_comment(g, owner, repo, number, f"Implementation complete — PR opened: {existing_pr}")
+                update_issue_state(issue_url, {"status": "done", "pr_url": existing_pr})
+                span.set_attribute("implement.status", "done")
+                span.set_attribute("implement.pr_url", existing_pr)
+                return
+
+        update_issue_state(issue_url, {"status": "implementing"})
+
+        issue = fetch_issue(g, owner, repo, number)
+        default_branch = get_default_branch(g, owner, repo)
+        repo_path = ensure_repo(owner, repo, default_branch)
+
+        plan_comment = fetch_comment(g, owner, repo, number, plan_comment_id)
+        plan_text = plan_comment.body
+
+        branch_name = issue_state.get("branch_name") or extract_branch_name(plan_text, number)
+        update_issue_state(issue_url, {"branch_name": branch_name})
+
+        all_comments = fetch_issue_comments(g, owner, repo, number)
+        discussion_text = _collect_discussion(all_comments, plan_comment_id)
+
+        prompt = _build_prompt(issue, plan_text, discussion_text, owner, repo, number, repo_path, branch_name)
+
+        log.info("Invoking Claude for implementation of issue #%d", number)
+        try:
+            output = invoke_claude(prompt, repo_path)
+        except UsageLimitError:
+            log.warning("Usage limit hit during implementation #%d — will retry next cycle", number)
+            span.set_attribute("implement.status", "limit")
+            update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing"})
             return
 
-    update_issue_state(issue_url, {"status": "implementing"})
-
-    issue = fetch_issue(g, owner, repo, number)
-    default_branch = get_default_branch(g, owner, repo)
-    repo_path = ensure_repo(owner, repo, default_branch)
-
-    plan_comment = fetch_comment(g, owner, repo, number, plan_comment_id)
-    plan_text = plan_comment.body
-
-    branch_name = issue_state.get("branch_name") or extract_branch_name(plan_text, number)
-    update_issue_state(issue_url, {"branch_name": branch_name})
-
-    all_comments = fetch_issue_comments(g, owner, repo, number)
-    discussion_text = _collect_discussion(all_comments, plan_comment_id)
-
-    prompt = _build_prompt(issue, plan_text, discussion_text, owner, repo, number, repo_path, branch_name)
-
-    log.info("Invoking Claude for implementation of issue #%d", number)
-    try:
-        output = invoke_claude(prompt, repo_path)
-    except UsageLimitError:
-        log.warning("Usage limit hit during implementation #%d — will retry next cycle", number)
-        update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing"})
-        return
-
-    pr_url = _extract_pr_url(output)
-    if not pr_url:
-        # Check if a PR was created but not captured in output
-        pr_url = find_open_pr(g, owner, repo, number)
-    if pr_url:
-        _post_result(g, owner, repo, number, pr_url)
-        update_issue_state(issue_url, {"status": "done", "pr_url": pr_url})
-        log.info("Issue #%d done — PR: %s", number, pr_url)
-    else:
-        log.error("Implementation of #%d produced no PR", number)
-        post_comment(g, owner, repo, number,
-                     "Implementation ran but no PR was created. "
-                     "I'll retry on the next cycle.")
-        update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing"})
+        pr_url = _extract_pr_url(output)
+        if not pr_url:
+            # Check if a PR was created but not captured in output
+            pr_url = find_open_pr(g, owner, repo, number)
+        if pr_url:
+            _post_result(g, owner, repo, number, pr_url)
+            update_issue_state(issue_url, {"status": "done", "pr_url": pr_url})
+            span.set_attribute("implement.status", "done")
+            span.set_attribute("implement.pr_url", pr_url)
+            log.info("Issue #%d done — PR: %s", number, pr_url)
+        else:
+            log.error("Implementation of #%d produced no PR", number)
+            post_comment(g, owner, repo, number,
+                         "Implementation ran but no PR was created. "
+                         "I'll retry on the next cycle.")
+            span.set_attribute("implement.status", "no_pr")
+            update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing"})
 
 
 

--- a/src/clayde/tasks/plan.py
+++ b/src/clayde/tasks/plan.py
@@ -16,6 +16,7 @@ from clayde.github import (
     post_comment,
 )
 from clayde.state import update_issue_state
+from clayde.telemetry import get_tracer
 
 log = logging.getLogger("clayde.tasks.plan")
 
@@ -23,44 +24,55 @@ _PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
 def run(issue_url: str) -> None:
-    g = get_github_client()
-    owner, repo, number = parse_issue_url(issue_url)
-    update_issue_state(issue_url, {
-        "status": "planning", "owner": owner, "repo": repo, "number": number,
-    })
+    tracer = get_tracer()
+    with tracer.start_as_current_span("clayde.task.plan") as span:
+        g = get_github_client()
+        owner, repo, number = parse_issue_url(issue_url)
+        span.set_attribute("issue.number", number)
+        span.set_attribute("issue.owner", owner)
+        span.set_attribute("issue.repo", repo)
+        update_issue_state(issue_url, {
+            "status": "planning", "owner": owner, "repo": repo, "number": number,
+        })
 
-    issue = fetch_issue(g, owner, repo, number)
-    default_branch = get_default_branch(g, owner, repo)
-    repo_path = ensure_repo(owner, repo, default_branch)
+        issue = fetch_issue(g, owner, repo, number)
+        default_branch = get_default_branch(g, owner, repo)
+        repo_path = ensure_repo(owner, repo, default_branch)
 
-    prompt = _build_prompt(g, issue, owner, repo, number, repo_path)
+        prompt = _build_prompt(g, issue, owner, repo, number, repo_path)
 
-    log.info("Invoking Claude for planning issue #%d", number)
-    try:
-        plan_text = invoke_claude(prompt, repo_path)
-    except UsageLimitError:
-        log.warning("Usage limit hit during planning #%d — will retry next cycle", number)
-        update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "planning"})
-        return
+        log.info("Invoking Claude for planning issue #%d", number)
+        try:
+            plan_text = invoke_claude(prompt, repo_path)
+        except UsageLimitError:
+            log.warning("Usage limit hit during planning #%d — will retry next cycle", number)
+            span.set_attribute("plan.status", "limit")
+            update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "planning"})
+            return
 
-    if not plan_text.strip():
-        log.error("Claude returned empty plan for issue #%d", number)
-        update_issue_state(issue_url, {"status": "failed"})
-        return
+        span.set_attribute("plan.output_length", len(plan_text))
 
-    # Reject suspiciously short output that may be a rate limit message
-    if len(plan_text.strip()) < 200:
-        log.warning("Claude returned very short plan for issue #%d (%d chars) — treating as failed",
-                     number, len(plan_text.strip()))
-        update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "planning"})
-        return
+        if not plan_text.strip():
+            log.error("Claude returned empty plan for issue #%d", number)
+            span.set_attribute("plan.status", "empty")
+            update_issue_state(issue_url, {"status": "failed"})
+            return
 
-    comment_id = _post_plan_comment(g, owner, repo, number, plan_text)
-    update_issue_state(issue_url, {
-        "status": "awaiting_approval",
-        "plan_comment_id": comment_id,
-    })
-    log.info("Plan posted for issue #%d (comment %s)", number, comment_id)
+        # Reject suspiciously short output that may be a rate limit message
+        if len(plan_text.strip()) < 200:
+            log.warning("Claude returned very short plan for issue #%d (%d chars) — treating as failed",
+                         number, len(plan_text.strip()))
+            span.set_attribute("plan.status", "short")
+            update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "planning"})
+            return
+
+        comment_id = _post_plan_comment(g, owner, repo, number, plan_text)
+        update_issue_state(issue_url, {
+            "status": "awaiting_approval",
+            "plan_comment_id": comment_id,
+        })
+        span.set_attribute("plan.status", "posted")
+        log.info("Plan posted for issue #%d (comment %s)", number, comment_id)
 
 
 def _build_prompt(g, issue, owner: str, repo: str, number: int, repo_path: str) -> str:

--- a/src/clayde/telemetry.py
+++ b/src/clayde/telemetry.py
@@ -1,0 +1,100 @@
+"""OpenTelemetry tracing setup for Clayde."""
+
+import json
+import logging
+import os
+from typing import Sequence
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+log = logging.getLogger("clayde.telemetry")
+
+_TRACES_FILE = os.path.join(
+    os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde"), "logs", "traces.jsonl"
+)
+
+
+class FileSpanExporter(SpanExporter):
+    """Append spans as JSONL to a file."""
+
+    def __init__(self, file_path: str):
+        self._file_path = file_path
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+    def export(self, spans: Sequence) -> SpanExportResult:
+        try:
+            with open(self._file_path, "a") as f:
+                for span in spans:
+                    f.write(json.dumps(_span_to_dict(span)) + "\n")
+            return SpanExportResult.SUCCESS
+        except Exception:
+            log.exception("Failed to export spans to file")
+            return SpanExportResult.FAILURE
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 0) -> bool:
+        return True
+
+
+def _span_to_dict(span) -> dict:
+    ctx = span.get_span_context()
+    parent = span.parent
+    return {
+        "name": span.name,
+        "trace_id": format(ctx.trace_id, "032x"),
+        "span_id": format(ctx.span_id, "016x"),
+        "parent_span_id": format(parent.span_id, "016x") if parent else None,
+        "start_time": span.start_time,
+        "end_time": span.end_time,
+        "duration_ms": (span.end_time - span.start_time) / 1_000_000 if span.end_time and span.start_time else None,
+        "status": span.status.status_code.name if span.status else None,
+        "attributes": dict(span.attributes) if span.attributes else {},
+        "events": [
+            {
+                "name": e.name,
+                "timestamp": e.timestamp,
+                "attributes": dict(e.attributes) if e.attributes else {},
+            }
+            for e in span.events
+        ],
+    }
+
+
+def init_tracer(traces_file: str | None = None) -> TracerProvider:
+    """Initialize and set the global TracerProvider.
+
+    Args:
+        traces_file: Path to JSONL traces file. Defaults to logs/traces.jsonl.
+
+    Returns:
+        The configured TracerProvider.
+    """
+    resource = Resource.create({"service.name": "clayde"})
+    provider = TracerProvider(resource=resource)
+
+    file_path = traces_file or _TRACES_FILE
+    provider.add_span_processor(SimpleSpanProcessor(FileSpanExporter(file_path)))
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint)))
+            log.info("OTLP exporter configured for %s", endpoint)
+        except Exception:
+            log.warning("Failed to configure OTLP exporter — continuing with file exporter only")
+
+    trace.set_tracer_provider(provider)
+    return provider
+
+
+def get_tracer() -> trace.Tracer:
+    """Return the clayde tracer."""
+    return trace.get_tracer("clayde")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,99 @@
+"""Tests for clayde.telemetry."""
+
+import json
+
+from opentelemetry.sdk.trace import TracerProvider
+
+from clayde.telemetry import FileSpanExporter, init_tracer
+
+
+class TestInitTracer:
+    def test_returns_tracer_provider(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        assert isinstance(provider, TracerProvider)
+
+    def test_creates_traces_file_on_export(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        tracer = provider.get_tracer("clayde")
+        with tracer.start_as_current_span("test"):
+            pass
+        provider.force_flush()
+        assert (tmp_path / "traces.jsonl").exists()
+
+
+class TestFileSpanExporter:
+    def test_creates_directory(self, tmp_path):
+        file_path = str(tmp_path / "subdir" / "traces.jsonl")
+        FileSpanExporter(file_path)
+        assert (tmp_path / "subdir").is_dir()
+
+    def test_exports_spans_to_file(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        tracer = provider.get_tracer("clayde")
+        with tracer.start_as_current_span("test.span") as span:
+            span.set_attribute("test.key", "test_value")
+        provider.force_flush()
+
+        lines = open(traces_file).readlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["name"] == "test.span"
+        assert data["attributes"]["test.key"] == "test_value"
+
+    def test_exports_nested_spans(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        tracer = provider.get_tracer("clayde")
+        with tracer.start_as_current_span("parent") as parent_span:
+            parent_span.set_attribute("level", "parent")
+            with tracer.start_as_current_span("child") as child_span:
+                child_span.set_attribute("level", "child")
+        provider.force_flush()
+
+        lines = open(traces_file).readlines()
+        assert len(lines) == 2
+        spans = [json.loads(line) for line in lines]
+        names = {s["name"] for s in spans}
+        assert names == {"parent", "child"}
+
+        child = next(s for s in spans if s["name"] == "child")
+        parent = next(s for s in spans if s["name"] == "parent")
+        assert child["parent_span_id"] == parent["span_id"]
+        assert child["trace_id"] == parent["trace_id"]
+
+    def test_exports_span_events(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        tracer = provider.get_tracer("clayde")
+        with tracer.start_as_current_span("test.span") as span:
+            span.add_event("state_transition", attributes={
+                "old_status": "(none)",
+                "new_status": "planning",
+            })
+        provider.force_flush()
+
+        lines = open(traces_file).readlines()
+        data = json.loads(lines[0])
+        assert len(data["events"]) == 1
+        assert data["events"][0]["name"] == "state_transition"
+        assert data["events"][0]["attributes"]["new_status"] == "planning"
+
+    def test_records_duration(self, tmp_path):
+        traces_file = str(tmp_path / "traces.jsonl")
+        provider = init_tracer(traces_file=traces_file)
+        tracer = provider.get_tracer("clayde")
+        with tracer.start_as_current_span("test.span"):
+            pass
+        provider.force_flush()
+
+        data = json.loads(open(traces_file).readline())
+        assert data["duration_ms"] is not None
+        assert data["duration_ms"] >= 0
+
+    def test_force_flush_returns_true(self, tmp_path):
+        file_path = str(tmp_path / "traces.jsonl")
+        exporter = FileSpanExporter(file_path)
+        assert exporter.force_flush() is True

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -140,6 +145,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic-settings" },
     { name = "pygithub" },
 ]
@@ -152,6 +160,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "opentelemetry-api", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pygithub", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -221,12 +232,77 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -314,6 +390,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/6f/7ee0980afcbdcd2d40362da16f7f9796bd083bf7f0b8e038abfbc0300f5d/opentelemetry_exporter_otlp_proto_grpc-1.40.0-py3-none-any.whl", hash = "sha256:2aa0ca53483fe0cf6405087a7491472b70335bc5c7944378a0a8e72e86995c52", size = 20304, upload-time = "2026-03-04T14:17:05.942Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -329,6 +487,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]
@@ -582,4 +755,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
Closes #9

## Summary

- **New `telemetry.py` module** with `FileSpanExporter` that writes JSONL traces to `logs/traces.jsonl`, plus optional OTLP gRPC export via `OTEL_EXPORTER_OTLP_ENDPOINT` env var
- **Orchestrator** instrumented with root `clayde.tick` span per cron invocation, child `clayde.handle_issue` spans per issue processed
- **Claude CLI** calls wrapped in `clayde.invoke_claude` and `clayde.claude_available_check` spans with exit code, output length, timeout, and usage limit attributes
- **Task runners** (`plan.py`, `implement.py`) wrapped in `clayde.task.plan` / `clayde.task.implement` spans with issue metadata and status attributes
- **State transitions** emit `state_transition` span events automatically from `update_issue_state()`
- Added `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc` dependencies
- 8 new tests in `test_telemetry.py`; all 111 tests pass

## Viewing traces

```bash
# View recent traces
tail -20 /home/ubuntu/clayde/logs/traces.jsonl | python3 -m json.tool

# Search for failures
grep '"issue.failed": true' /home/ubuntu/clayde/logs/traces.jsonl
```

## Span hierarchy

```
clayde.tick
├── clayde.claude_available_check
├── clayde.handle_issue
│   ├── clayde.task.plan
│   │   └── clayde.invoke_claude
│   ├── clayde.task.implement
│   │   └── clayde.invoke_claude
│   └── (state_transition events)
```

## Test plan

- [x] All 111 existing + new tests pass
- [ ] Manual smoke test: run `uv run clayde`, verify `logs/traces.jsonl` contains valid spans
- [ ] Verify span parent-child relationships in trace output