### PR TITLE
Use pathlib.Path throughout the project

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+from pathlib import Path
 
 from clayde.config import get_settings
 from clayde.telemetry import get_tracer
@@ -43,12 +44,12 @@ def invoke_claude(prompt, repo_path):
     """
     tracer = get_tracer()
     with tracer.start_as_current_span("clayde.invoke_claude") as span:
-        identity = open(os.path.join(str(get_settings().dir), "CLAUDE.md")).read()
+        identity = (get_settings().dir / "CLAUDE.md").read_text()
 
         try:
             result = subprocess.run(
                 [
-                    os.path.expanduser("~/.local/bin/claude"), "-p", prompt,
+                    str(Path.home() / ".local/bin/claude"), "-p", prompt,
                     "--append-system-prompt", identity,
                     "--dangerously-skip-permissions",
                 ],
@@ -101,7 +102,7 @@ def is_claude_available():
     with tracer.start_as_current_span("clayde.claude_available_check") as span:
         try:
             result = subprocess.run(
-                [os.path.expanduser("~/.local/bin/claude"), "-p", "respond with: OK"],
+                [str(Path.home() / ".local/bin/claude"), "-p", "respond with: OK"],
                 env=_make_env(),
                 text=True,
                 capture_output=True,

--- a/src/clayde/config.py
+++ b/src/clayde/config.py
@@ -13,7 +13,7 @@ _settings: "Settings | None" = None
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="CLAYDE_",
-        env_file=os.path.join(os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde"), "config.env"),
+        env_file=Path(os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde")) / "config.env",
         env_file_encoding="utf-8",
     )
 
@@ -28,16 +28,16 @@ class Settings(BaseSettings):
         return [u.strip() for u in self.whitelisted_users.split(",") if u.strip()]
 
     @property
-    def state_file(self) -> str:
-        return str(self.dir / "state.json")
+    def state_file(self) -> Path:
+        return self.dir / "state.json"
 
     @property
-    def log_file(self) -> str:
-        return str(self.dir / "logs" / "agent.log")
+    def log_file(self) -> Path:
+        return self.dir / "logs" / "agent.log"
 
     @property
-    def repos_dir(self) -> str:
-        return str(self.dir / "repos")
+    def repos_dir(self) -> Path:
+        return self.dir / "repos"
 
 
 def get_settings() -> Settings:
@@ -62,7 +62,7 @@ def get_github_client() -> "Github":
 def setup_logging() -> None:
     """Configure stdlib logging to append to the agent log file."""
     log_file = get_settings().log_file
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    log_file.parent.mkdir(parents=True, exist_ok=True)
     handler = logging.FileHandler(log_file)
     handler.setFormatter(logging.Formatter(
         "[%(asctime)s] [%(name)s] %(message)s",

--- a/src/clayde/git.py
+++ b/src/clayde/git.py
@@ -1,24 +1,24 @@
 """Git repository management — clone or update repos under REPOS_DIR."""
 
 import logging
-import os
 import subprocess
+from pathlib import Path
 
 from clayde.config import get_settings
 
 log = logging.getLogger("clayde.git")
 
 
-def ensure_repo(owner: str, repo: str, default_branch: str) -> str:
+def ensure_repo(owner: str, repo: str, default_branch: str) -> Path:
     """Clone repo if needed, otherwise checkout default_branch and pull.
 
     Returns the local path to the repository.
     """
     repos_dir = get_settings().repos_dir
-    repo_path = os.path.join(repos_dir, f"{owner}__{repo}")
+    repo_path = repos_dir / f"{owner}__{repo}"
     clone_url = f"https://github.com/{owner}/{repo}.git"
 
-    if os.path.isdir(os.path.join(repo_path, ".git")):
+    if (repo_path / ".git").is_dir():
         log.info("Updating %s/%s (checkout %s + pull)", owner, repo, default_branch)
         subprocess.run(
             ["git", "checkout", default_branch],
@@ -27,9 +27,9 @@ def ensure_repo(owner: str, repo: str, default_branch: str) -> str:
         subprocess.run(["git", "pull"], cwd=repo_path, capture_output=True)
     else:
         log.info("Cloning %s/%s", owner, repo)
-        os.makedirs(repos_dir, exist_ok=True)
+        repos_dir.mkdir(parents=True, exist_ok=True)
         result = subprocess.run(
-            ["git", "clone", clone_url, repo_path],
+            ["git", "clone", clone_url, str(repo_path)],
             capture_output=True, text=True,
         )
         if result.returncode != 0:

--- a/src/clayde/state.py
+++ b/src/clayde/state.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 
 from opentelemetry import trace
 
@@ -13,15 +12,13 @@ log = logging.getLogger("clayde.state")
 
 def load_state():
     state_file = get_settings().state_file
-    if os.path.exists(state_file):
-        with open(state_file) as f:
-            return json.load(f)
+    if state_file.exists():
+        return json.loads(state_file.read_text())
     return {"issues": {}}
 
 
 def save_state(state):
-    with open(get_settings().state_file, "w") as f:
-        json.dump(state, f, indent=2)
+    get_settings().state_file.write_text(json.dumps(state, indent=2))
 
 
 def get_issue_state(issue_url):

--- a/src/clayde/telemetry.py
+++ b/src/clayde/telemetry.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Sequence
 
 from opentelemetry import trace
@@ -12,8 +13,8 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, Sp
 
 log = logging.getLogger("clayde.telemetry")
 
-_TRACES_FILE = os.path.join(
-    os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde"), "logs", "traces.jsonl"
+_TRACES_FILE = str(
+    Path(os.environ.get("CLAYDE_DIR", "/home/ubuntu/clayde")) / "logs" / "traces.jsonl"
 )
 
 
@@ -21,8 +22,8 @@ class FileSpanExporter(SpanExporter):
     """Append spans as JSONL to a file."""
 
     def __init__(self, file_path: str):
-        self._file_path = file_path
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        self._file_path = Path(file_path)
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
 
     def export(self, spans: Sequence) -> SpanExportResult:
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for clayde.config."""
 
 import logging
+from pathlib import Path
 from unittest.mock import patch
 
 from clayde.config import Settings, _reset_settings, get_settings, setup_logging
@@ -44,9 +45,9 @@ class TestSettings:
     def test_derived_paths(self, monkeypatch):
         monkeypatch.setenv("CLAYDE_DIR", "/custom/dir")
         s = Settings(_env_file=None)
-        assert s.state_file == "/custom/dir/state.json"
-        assert s.log_file == "/custom/dir/logs/agent.log"
-        assert s.repos_dir == "/custom/dir/repos"
+        assert s.state_file == Path("/custom/dir/state.json")
+        assert s.log_file == Path("/custom/dir/logs/agent.log")
+        assert s.repos_dir == Path("/custom/dir/repos")
 
     def test_value_with_equals_sign(self, tmp_path, monkeypatch):
         env_file = tmp_path / "config.env"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,6 @@
 """Tests for clayde.git."""
 
-import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,30 +10,30 @@ import clayde.git as git_mod
 
 def _mock_settings(repos_dir):
     s = MagicMock()
-    s.repos_dir = repos_dir
+    s.repos_dir = Path(repos_dir)
     return s
 
 
 class TestEnsureRepo:
     def test_clones_when_no_git_dir(self, tmp_path):
-        repo_path = os.path.join(str(tmp_path), "alice__myrepo")
+        repo_path = tmp_path / "alice__myrepo"
 
-        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+        with patch("clayde.git.get_settings", return_value=_mock_settings(tmp_path)), \
              patch("clayde.git.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             result = git_mod.ensure_repo("alice", "myrepo", "main")
 
         assert result == repo_path
         mock_run.assert_called_once_with(
-            ["git", "clone", "https://github.com/alice/myrepo.git", repo_path],
+            ["git", "clone", "https://github.com/alice/myrepo.git", str(repo_path)],
             capture_output=True, text=True,
         )
 
     def test_updates_when_git_dir_exists(self, tmp_path):
-        repo_path = os.path.join(str(tmp_path), "alice__myrepo")
-        os.makedirs(os.path.join(repo_path, ".git"))
+        repo_path = tmp_path / "alice__myrepo"
+        (repo_path / ".git").mkdir(parents=True)
 
-        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+        with patch("clayde.git.get_settings", return_value=_mock_settings(tmp_path)), \
              patch("clayde.git.subprocess.run") as mock_run:
             result = git_mod.ensure_repo("alice", "myrepo", "main")
 
@@ -47,7 +47,7 @@ class TestEnsureRepo:
         )
 
     def test_clone_failure_raises(self, tmp_path):
-        with patch("clayde.git.get_settings", return_value=_mock_settings(str(tmp_path))), \
+        with patch("clayde.git.get_settings", return_value=_mock_settings(tmp_path)), \
              patch("clayde.git.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="fatal: not found")
             with pytest.raises(RuntimeError, match="Clone failed"):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,7 @@
 """Tests for clayde.state."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import clayde.state as state_mod
@@ -8,7 +9,7 @@ import clayde.state as state_mod
 
 def _mock_settings(state_file):
     s = MagicMock()
-    s.state_file = state_file
+    s.state_file = Path(state_file)
     return s
 
 


### PR DESCRIPTION
Closes #16

## Summary

- **Settings properties** (`state_file`, `log_file`, `repos_dir`) now return `Path` objects instead of strings
- **Replaced all `os.path` and `os.makedirs`** usage in `src/clayde/` with `pathlib.Path` operations (`/`, `.exists()`, `.is_dir()`, `.mkdir()`, `.read_text()`, `.write_text()`)
- **`ensure_repo()` returns `Path`** instead of `str` (per discussion feedback)
- **Updated tests** to use `Path` objects in mocks and assertions
- **Kept `import os`** only in modules that still use `os.environ`

## Files changed

- `src/clayde/config.py` — Path return types, `Path.parent.mkdir()` instead of `os.makedirs`
- `src/clayde/state.py` — `Path.exists()`, `.read_text()`, `.write_text()` instead of `os.path.exists`/`open()`
- `src/clayde/claude.py` — `Path.home()`, `Path.read_text()` instead of `os.path.expanduser`/`os.path.join`
- `src/clayde/git.py` — Full pathlib migration, returns `Path`
- `src/clayde/telemetry.py` — `Path` for traces file path construction
- `tests/test_config.py`, `tests/test_state.py`, `tests/test_git.py` — Updated for `Path` types

## Test plan

- [x] All 111 existing tests pass
- [x] No remaining `os.path` or `os.makedirs` in `src/clayde/`
- [x] `import os` only present where `os.environ` is used