### PR TITLE
Fix entrypoint to avoid runtime PyPI dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN mkdir -p /data/repos /data/logs
 
 ENV CLAYDE_DIR=/data
 
-ENTRYPOINT ["uv", "run", "clayde"]
+ENTRYPOINT ["/app/.venv/bin/clayde"]


### PR DESCRIPTION
## Summary
- Changed entrypoint from `uv run clayde` to `/app/.venv/bin/clayde`
- `uv run` re-resolves the project environment at container start, requiring network access to PyPI to fetch `hatchling` and other build dependencies
- Since `uv sync --frozen --no-dev` already installs everything during the Docker build phase, we can call the installed script directly
- This fixes the container crash loop when outbound internet is unavailable at runtime

## Test plan
- [ ] Build the image: `docker build -t clayde-test .`
- [ ] Run without internet access and verify it starts successfully
- [ ] Verify `clayde` functions normally with the new entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)