### PR TITLE
Add persistence for interrupted Claude API sessions

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -1,5 +1,6 @@
 """Claude API invocation via the Anthropic Python SDK."""
 
+import json
 import logging
 import subprocess
 import time
@@ -117,7 +118,104 @@ def _execute_tool(block, cwd: str) -> str:
         return f"[error: unknown tool: {block.name}]"
 
 
-def invoke_claude(prompt: str, repo_path: str) -> str:
+def _commit_wip(repo_path: str, branch_name: str) -> None:
+    """Commit and push any working tree changes as WIP.
+
+    Never raises — failures are logged and swallowed so the original
+    error (e.g. rate limit) is not masked.
+    """
+    try:
+        cwd = repo_path
+        # Checkout or create the branch
+        result = subprocess.run(
+            ["git", "checkout", branch_name],
+            cwd=cwd, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            subprocess.run(
+                ["git", "checkout", "-b", branch_name],
+                cwd=cwd, capture_output=True, text=True, check=True,
+            )
+
+        subprocess.run(["git", "add", "-A"], cwd=cwd, capture_output=True, check=True)
+
+        # Check if there are staged changes
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=cwd, capture_output=True,
+        )
+        if result.returncode == 0:
+            log.info("No changes to commit as WIP")
+            return
+
+        subprocess.run(
+            ["git", "commit", "-m", "WIP: interrupted by rate limit"],
+            cwd=cwd, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "push", "--force", "origin", branch_name],
+            cwd=cwd, capture_output=True, check=True,
+        )
+        log.info("WIP committed and pushed to %s", branch_name)
+    except Exception as e:
+        log.warning("Failed to commit WIP: %s", e)
+
+
+def _serialize_messages(messages: list) -> list:
+    """Serialize messages for JSON persistence.
+
+    Assistant messages contain Anthropic SDK pydantic content blocks
+    that need .model_dump(). User messages are already plain dicts.
+    """
+    serialized = []
+    for msg in messages:
+        if msg["role"] == "assistant":
+            content = msg["content"]
+            if isinstance(content, list):
+                dumped = []
+                for block in content:
+                    if hasattr(block, "model_dump"):
+                        dumped.append(block.model_dump())
+                    else:
+                        dumped.append(block)
+                serialized.append({"role": "assistant", "content": dumped})
+            else:
+                serialized.append(msg)
+        else:
+            serialized.append(msg)
+    return serialized
+
+
+def _save_conversation(conversation_path: Path, messages: list) -> None:
+    """Save conversation messages to a JSON file."""
+    try:
+        conversation_path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = _serialize_messages(messages)
+        conversation_path.write_text(json.dumps(serialized, default=str))
+        log.info("Saved conversation (%d messages) to %s", len(messages), conversation_path)
+    except Exception as e:
+        log.warning("Failed to save conversation: %s", e)
+
+
+def _load_conversation(conversation_path: Path) -> list | None:
+    """Load conversation messages from a JSON file. Returns None if not found."""
+    try:
+        if conversation_path.exists():
+            messages = json.loads(conversation_path.read_text())
+            log.info("Loaded conversation (%d messages) from %s", len(messages), conversation_path)
+            return messages
+    except Exception as e:
+        log.warning("Failed to load conversation: %s", e)
+    return None
+
+
+def invoke_claude(
+    prompt: str,
+    repo_path: str,
+    *,
+    branch_name: str | None = None,
+    conversation_path: Path | None = None,
+) -> str:
     """Invoke the Claude API with the given prompt.
 
     Uses tool-use mode (bash + text_editor) so Claude can explore and
@@ -126,6 +224,10 @@ def invoke_claude(prompt: str, repo_path: str) -> str:
     Args:
         prompt: The user prompt to send to Claude.
         repo_path: Path to the repository (used as cwd for tool execution).
+        branch_name: If provided, WIP changes are committed to this branch
+            on rate limit interruption.
+        conversation_path: If provided, conversation is saved to this path
+            on interruption and resumed from it on next invocation.
 
     Raises:
         UsageLimitError: When the Claude API reports a rate/usage limit.
@@ -147,7 +249,25 @@ def invoke_claude(prompt: str, repo_path: str) -> str:
                 {"type": "bash_20250124", "name": "bash"},
                 {"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
             ]
-            messages = [{"role": "user", "content": prompt}]
+
+            # Try to resume from a saved conversation
+            resumed = False
+            if conversation_path:
+                saved = _load_conversation(conversation_path)
+                if saved:
+                    messages = saved
+                    messages.append({"role": "user", "content":
+                        "You were interrupted by a rate limit. Your previous edits have been "
+                        "preserved on the branch. Continue where you left off."})
+                    resumed = True
+                    span.set_attribute("claude.resumed", True)
+                    span.set_attribute("claude.resumed_messages", len(saved))
+                    log.info("Resuming conversation with %d existing messages", len(saved))
+
+            if not resumed:
+                messages = [{"role": "user", "content": prompt}]
+                span.set_attribute("claude.resumed", False)
+
             deadline = time.monotonic() + 1800
             turn_count = 0
             output = ""
@@ -204,6 +324,10 @@ def invoke_claude(prompt: str, repo_path: str) -> str:
 
         except anthropic.RateLimitError as e:
             log.error("Claude API rate limit hit: %s", e)
+            if branch_name:
+                _commit_wip(repo_path, branch_name)
+            if conversation_path:
+                _save_conversation(conversation_path, messages)
             span.set_attribute("claude.usage_limit", True)
             exc = UsageLimitError(f"Claude API rate limit: {e}")
             span.record_exception(exc)
@@ -212,6 +336,10 @@ def invoke_claude(prompt: str, repo_path: str) -> str:
         except anthropic.APIStatusError as e:
             if e.status_code == 529:
                 log.error("Claude API overloaded (529): %s", e)
+                if branch_name:
+                    _commit_wip(repo_path, branch_name)
+                if conversation_path:
+                    _save_conversation(conversation_path, messages)
                 span.set_attribute("claude.usage_limit", True)
                 exc = UsageLimitError(f"Claude API overloaded: {e}")
                 span.record_exception(exc)

--- a/src/clayde/tasks/implement.py
+++ b/src/clayde/tasks/implement.py
@@ -1,12 +1,13 @@
 """Implement task — implement the approved plan, open PR, post result."""
 
 import logging
+import subprocess
 from pathlib import Path
 
 from jinja2 import Environment, StrictUndefined
 
 from clayde.claude import UsageLimitError, invoke_claude
-from clayde.config import get_github_client
+from clayde.config import DATA_DIR, get_github_client
 from clayde.git import ensure_repo
 from clayde.github import (
     create_pull_request,
@@ -65,16 +66,29 @@ def run(issue_url: str) -> None:
         branch_name = issue_state.get("branch_name") or extract_branch_name(plan_text, number)
         update_issue_state(issue_url, {"branch_name": branch_name})
 
+        # If resuming an interrupted implementation, checkout the WIP branch
+        if resumed and branch_name:
+            _checkout_wip_branch(repo_path, branch_name)
+
         all_comments = fetch_issue_comments(g, owner, repo, number)
         discussion_text = _collect_discussion(all_comments, plan_comment_id)
 
         prompt = _build_prompt(issue, plan_text, discussion_text, owner, repo, number, repo_path, branch_name)
 
+        conv_path = DATA_DIR / "conversations" / f"{owner}__{repo}__issue-{number}.json"
+        conv_path.parent.mkdir(parents=True, exist_ok=True)
+
         log.info("Invoking Claude for implementation of issue #%d", number)
         try:
-            output = invoke_claude(prompt, repo_path)
+            output = invoke_claude(
+                prompt,
+                repo_path,
+                branch_name=branch_name,
+                conversation_path=conv_path,
+            )
         except UsageLimitError:
             log.warning("Usage limit hit during implementation #%d — will retry next cycle", number)
+            log.info("Conversation saved to %s", conv_path)
             span.set_attribute("implement.status", "limit")
             update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing"})
             return
@@ -99,6 +113,7 @@ def run(issue_url: str) -> None:
         if pr_url:
             _post_result(g, owner, repo, number, pr_url)
             update_issue_state(issue_url, {"status": "done", "pr_url": pr_url})
+            log.info("Conversation saved to %s", conv_path)
             span.set_attribute("implement.status", "done")
             span.set_attribute("implement.pr_url", pr_url)
             log.info("Issue #%d done — PR: %s", number, pr_url)
@@ -122,6 +137,37 @@ def run(issue_url: str) -> None:
                 update_issue_state(issue_url, {"status": "interrupted", "interrupted_phase": "implementing",
                                                "retry_count": retry_count})
 
+
+
+def _checkout_wip_branch(repo_path, branch_name: str) -> None:
+    """Checkout an existing WIP branch if it exists (locally or on remote)."""
+    cwd = str(repo_path)
+
+    # Check local branch
+    result = subprocess.run(
+        ["git", "branch", "--list", branch_name],
+        cwd=cwd, capture_output=True, text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(["git", "checkout", branch_name], cwd=cwd, capture_output=True)
+        subprocess.run(["git", "pull", "origin", branch_name], cwd=cwd, capture_output=True)
+        log.info("Resumed WIP branch %s (local)", branch_name)
+        return
+
+    # Check remote branch
+    result = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", branch_name],
+        cwd=cwd, capture_output=True, text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(
+            ["git", "checkout", "-b", branch_name, f"origin/{branch_name}"],
+            cwd=cwd, capture_output=True,
+        )
+        log.info("Resumed WIP branch %s (remote)", branch_name)
+        return
+
+    log.info("No existing WIP branch %s found — starting fresh", branch_name)
 
 
 def _collect_discussion(all_comments, plan_comment_id: int) -> str:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,5 +1,6 @@
 """Tests for clayde.claude."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -9,7 +10,11 @@ import anthropic
 from clayde.claude import (
     UsageLimitError,
     _calculate_cost_usd,
+    _commit_wip,
     _execute_tool,
+    _load_conversation,
+    _save_conversation,
+    _serialize_messages,
     invoke_claude,
     is_claude_available,
 )
@@ -318,3 +323,183 @@ class TestIsClaudeAvailable:
         with patch("clayde.claude._get_client", return_value=mock_client), \
              patch("clayde.claude.get_settings", return_value=_mock_settings("/tmp")):
             assert is_claude_available() is True
+
+
+class TestCommitWip:
+    def test_commits_and_pushes_changes(self, tmp_path):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            # git checkout branch_name fails (doesn't exist)
+            if cmd == ["git", "checkout", "clayde/issue-1"]:
+                result.returncode = 1
+                return result
+            # git diff --cached --quiet returns 1 (has changes)
+            if cmd == ["git", "diff", "--cached", "--quiet"]:
+                result.returncode = 1
+                return result
+            result.returncode = 0
+            return result
+
+        with patch("clayde.claude.subprocess.run", side_effect=fake_run):
+            _commit_wip("/repo", "clayde/issue-1")
+
+        cmd_strs = [" ".join(c) for c in calls]
+        assert any("checkout -b clayde/issue-1" in s for s in cmd_strs)
+        assert any("add -A" in s for s in cmd_strs)
+        assert any("commit -m" in s for s in cmd_strs)
+        assert any("push --force origin clayde/issue-1" in s for s in cmd_strs)
+
+    def test_skips_commit_when_no_changes(self, tmp_path):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.returncode = 0  # git diff --cached --quiet returns 0 (no changes)
+            return result
+
+        with patch("clayde.claude.subprocess.run", side_effect=fake_run):
+            _commit_wip("/repo", "clayde/issue-1")
+
+        cmd_strs = [" ".join(c) for c in calls]
+        assert not any("commit" in s for s in cmd_strs)
+
+    def test_never_raises(self):
+        with patch("clayde.claude.subprocess.run", side_effect=OSError("fail")):
+            # Should not raise
+            _commit_wip("/repo", "branch")
+
+
+class TestConversationPersistence:
+    def test_serialize_messages_with_pydantic_blocks(self):
+        mock_block = MagicMock()
+        mock_block.model_dump.return_value = {"type": "text", "text": "hello"}
+
+        messages = [
+            {"role": "user", "content": "prompt"},
+            {"role": "assistant", "content": [mock_block]},
+        ]
+        result = _serialize_messages(messages)
+        assert result[0] == {"role": "user", "content": "prompt"}
+        assert result[1] == {"role": "assistant", "content": [{"type": "text", "text": "hello"}]}
+        mock_block.model_dump.assert_called_once()
+
+    def test_serialize_messages_with_plain_dicts(self):
+        messages = [
+            {"role": "user", "content": "prompt"},
+            {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        ]
+        result = _serialize_messages(messages)
+        assert result == messages
+
+    def test_save_and_load_conversation(self, tmp_path):
+        conv_path = tmp_path / "conv.json"
+        messages = [
+            {"role": "user", "content": "prompt"},
+            {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        ]
+        _save_conversation(conv_path, messages)
+        loaded = _load_conversation(conv_path)
+        assert loaded == messages
+
+    def test_load_nonexistent_returns_none(self, tmp_path):
+        assert _load_conversation(tmp_path / "missing.json") is None
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        conv_path = tmp_path / "sub" / "dir" / "conv.json"
+        _save_conversation(conv_path, [{"role": "user", "content": "test"}])
+        assert conv_path.exists()
+
+    def test_rate_limit_saves_conversation(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        conv_path = tmp_path / "conv.json"
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.side_effect = anthropic.RateLimitError(
+            message="rate limit", response=MagicMock(), body={}
+        )
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings()), \
+             patch("clayde.claude._get_client", return_value=mock_client), \
+             patch("clayde.claude._commit_wip") as mock_wip:
+            with pytest.raises(UsageLimitError):
+                invoke_claude("prompt", "/repo", branch_name="branch", conversation_path=conv_path)
+
+        assert conv_path.exists()
+        saved = json.loads(conv_path.read_text())
+        assert len(saved) == 1
+        assert saved[0]["role"] == "user"
+        mock_wip.assert_called_once_with("/repo", "branch")
+
+    def test_rate_limit_529_saves_conversation(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        conv_path = tmp_path / "conv.json"
+
+        mock_response_obj = MagicMock()
+        mock_response_obj.status_code = 529
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.side_effect = anthropic.APIStatusError(
+            message="overloaded", response=mock_response_obj, body={}
+        )
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings()), \
+             patch("clayde.claude._get_client", return_value=mock_client), \
+             patch("clayde.claude._commit_wip"):
+            with pytest.raises(UsageLimitError):
+                invoke_claude("prompt", "/repo", branch_name="b", conversation_path=conv_path)
+
+        assert conv_path.exists()
+
+    def test_resumes_from_saved_conversation(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        conv_path = tmp_path / "conv.json"
+
+        # Save a prior conversation
+        prior_messages = [
+            {"role": "user", "content": "original prompt"},
+            {"role": "assistant", "content": [{"type": "text", "text": "working on it"}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+        ]
+        conv_path.write_text(json.dumps(prior_messages))
+
+        end_response = _make_end_turn_response("resumed output")
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = end_response
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings()), \
+             patch("clayde.claude._get_client", return_value=mock_client):
+            result = invoke_claude("new prompt", str(tmp_path), conversation_path=conv_path)
+
+        assert result == "resumed output"
+        # Check the first call's messages (before the loop mutates it)
+        first_call = mock_client.beta.messages.create.call_args_list[0]
+        messages_sent = first_call.kwargs["messages"]
+        # 3 prior + 1 resume + 1 assistant appended by loop = 5, but we check
+        # the resume message was at index 3 before the call
+        assert any("interrupted" in str(m.get("content", "")).lower() for m in messages_sent if m["role"] == "user")
+
+    def test_no_resume_without_conversation_file(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        conv_path = tmp_path / "conv.json"  # Does not exist
+
+        end_response = _make_end_turn_response("fresh output")
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = end_response
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings()), \
+             patch("clayde.claude._get_client", return_value=mock_client):
+            result = invoke_claude("prompt", str(tmp_path), conversation_path=conv_path)
+
+        assert result == "fresh output"
+        first_call = mock_client.beta.messages.create.call_args_list[0]
+        messages_sent = first_call.kwargs["messages"]
+        # First message should be the user prompt, second is the assistant response appended by the loop
+        assert messages_sent[0]["content"] == "prompt"
+        assert messages_sent[0]["role"] == "user"

--- a/tests/test_tasks_implement.py
+++ b/tests/test_tasks_implement.py
@@ -1,9 +1,11 @@
 """Tests for clayde.tasks.implement."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from clayde.claude import UsageLimitError
 from clayde.tasks.implement import (
+    _checkout_wip_branch,
     _collect_discussion,
     _post_result,
     run,
@@ -59,7 +61,7 @@ class TestPostResult:
 
 
 class TestRun:
-    def test_full_success_creates_pr(self):
+    def test_full_success_creates_pr(self, tmp_path):
         with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
              patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
@@ -73,7 +75,8 @@ class TestRun:
              patch("clayde.tasks.implement.invoke_claude", return_value="IMPLEMENTATION_COMPLETE"), \
              patch("clayde.tasks.implement.find_open_pr", return_value=None), \
              patch("clayde.tasks.implement.create_pull_request", return_value="https://github.com/o/r/pull/5") as mock_cpr, \
-             patch("clayde.tasks.implement._post_result"):
+             patch("clayde.tasks.implement._post_result"), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
             mock_fc.return_value.body = "plan text"
             mock_fi.return_value.title = "Test issue"
             run("https://github.com/o/r/issues/1")
@@ -83,7 +86,7 @@ class TestRun:
         assert last_call[0][1]["status"] == "done"
         assert last_call[0][1]["pr_url"] == "https://github.com/o/r/pull/5"
 
-    def test_existing_pr_reused(self):
+    def test_existing_pr_reused(self, tmp_path):
         with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
              patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
@@ -97,7 +100,8 @@ class TestRun:
              patch("clayde.tasks.implement.invoke_claude", return_value="IMPLEMENTATION_COMPLETE"), \
              patch("clayde.tasks.implement.find_open_pr", return_value="https://github.com/o/r/pull/5"), \
              patch("clayde.tasks.implement.create_pull_request") as mock_cpr, \
-             patch("clayde.tasks.implement._post_result"):
+             patch("clayde.tasks.implement._post_result"), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
             mock_fc.return_value.body = "plan text"
             run("https://github.com/o/r/issues/1")
 
@@ -106,7 +110,7 @@ class TestRun:
         assert last_call[0][1]["status"] == "done"
         assert last_call[0][1]["pr_url"] == "https://github.com/o/r/pull/5"
 
-    def test_usage_limit_sets_interrupted(self):
+    def test_usage_limit_sets_interrupted(self, tmp_path):
         with patch("clayde.tasks.implement.get_github_client"), \
              patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
@@ -117,7 +121,8 @@ class TestRun:
              patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
              patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
              patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
-             patch("clayde.tasks.implement.invoke_claude", side_effect=UsageLimitError("limit")):
+             patch("clayde.tasks.implement.invoke_claude", side_effect=UsageLimitError("limit")), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
             mock_fc.return_value.body = "plan text"
             run("url")
 
@@ -139,7 +144,7 @@ class TestRun:
 
         mock_update.assert_called_once_with("url", {"status": "done", "pr_url": "https://github.com/o/r/pull/5"})
 
-    def test_pr_creation_failure_sets_interrupted(self):
+    def test_pr_creation_failure_sets_interrupted(self, tmp_path):
         with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
              patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
@@ -153,7 +158,8 @@ class TestRun:
              patch("clayde.tasks.implement.invoke_claude", return_value="IMPLEMENTATION_COMPLETE"), \
              patch("clayde.tasks.implement.find_open_pr", return_value=None), \
              patch("clayde.tasks.implement.create_pull_request", side_effect=Exception("API error")), \
-             patch("clayde.tasks.implement.post_comment"):
+             patch("clayde.tasks.implement.post_comment"), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
             mock_fc.return_value.body = "plan text"
             mock_fi.return_value.title = "Test issue"
             run("https://github.com/o/r/issues/1")
@@ -163,7 +169,7 @@ class TestRun:
         assert last_call[0][1]["interrupted_phase"] == "implementing"
         assert last_call[0][1]["retry_count"] == 1
 
-    def test_no_pr_fails_after_max_retries(self):
+    def test_no_pr_fails_after_max_retries(self, tmp_path):
         with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
              patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100, "retry_count": 2}), \
@@ -177,7 +183,8 @@ class TestRun:
              patch("clayde.tasks.implement.invoke_claude", return_value="IMPLEMENTATION_COMPLETE"), \
              patch("clayde.tasks.implement.find_open_pr", return_value=None), \
              patch("clayde.tasks.implement.create_pull_request", side_effect=Exception("API error")), \
-             patch("clayde.tasks.implement.post_comment"):
+             patch("clayde.tasks.implement.post_comment"), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
             mock_fc.return_value.body = "plan text"
             mock_fi.return_value.title = "Test issue"
             run("https://github.com/o/r/issues/1")
@@ -202,3 +209,133 @@ class TestRun:
         assert "/tmp/repo" in prompt
         assert "42" in prompt
         assert "clayde/issue-42-test-branch" in prompt
+
+    def test_conversation_path_passed_to_invoke_claude(self):
+        with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
+             patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
+             patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
+             patch("clayde.tasks.implement.update_issue_state"), \
+             patch("clayde.tasks.implement.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.implement.get_default_branch", return_value="main"), \
+             patch("clayde.tasks.implement.ensure_repo", return_value="/tmp/repo"), \
+             patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
+             patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
+             patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
+             patch("clayde.tasks.implement.invoke_claude", return_value="done") as mock_claude, \
+             patch("clayde.tasks.implement.find_open_pr", return_value="https://github.com/o/r/pull/5"), \
+             patch("clayde.tasks.implement._post_result"), \
+             patch("clayde.tasks.implement.DATA_DIR", Path("/tmp/test-data")):
+            mock_fc.return_value.body = "plan text"
+            mock_fi.return_value.title = "Test"
+            run("https://github.com/o/r/issues/1")
+
+        call_kwargs = mock_claude.call_args
+        assert call_kwargs.kwargs["branch_name"] is not None
+        assert call_kwargs.kwargs["conversation_path"] is not None
+        assert "o__r__issue-1" in str(call_kwargs.kwargs["conversation_path"])
+
+    def test_conversation_preserved_on_success(self, tmp_path):
+        conv_dir = tmp_path / "conversations"
+        conv_dir.mkdir()
+        conv_file = conv_dir / "o__r__issue-1.json"
+        conv_file.write_text("[]")
+
+        with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
+             patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
+             patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
+             patch("clayde.tasks.implement.update_issue_state"), \
+             patch("clayde.tasks.implement.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.implement.get_default_branch", return_value="main"), \
+             patch("clayde.tasks.implement.ensure_repo", return_value="/tmp/repo"), \
+             patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
+             patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
+             patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
+             patch("clayde.tasks.implement.invoke_claude", return_value="done"), \
+             patch("clayde.tasks.implement.find_open_pr", return_value="https://github.com/o/r/pull/5"), \
+             patch("clayde.tasks.implement._post_result"), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
+            mock_fc.return_value.body = "plan text"
+            mock_fi.return_value.title = "Test"
+            run("https://github.com/o/r/issues/1")
+
+        assert conv_file.exists()
+
+    def test_resumed_issue_checks_out_wip_branch(self):
+        state = {
+            "plan_comment_id": 100,
+            "status": "interrupted",
+            "branch_name": "clayde/issue-1-fix",
+        }
+        with patch("clayde.tasks.implement.get_github_client") as mock_gc, \
+             patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
+             patch("clayde.tasks.implement.get_issue_state", return_value=state), \
+             patch("clayde.tasks.implement.find_open_pr", return_value=None), \
+             patch("clayde.tasks.implement.update_issue_state"), \
+             patch("clayde.tasks.implement.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.implement.get_default_branch", return_value="main"), \
+             patch("clayde.tasks.implement.ensure_repo", return_value="/tmp/repo"), \
+             patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
+             patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
+             patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
+             patch("clayde.tasks.implement.invoke_claude", return_value="done"), \
+             patch("clayde.tasks.implement.create_pull_request", return_value="https://github.com/o/r/pull/5"), \
+             patch("clayde.tasks.implement._post_result"), \
+             patch("clayde.tasks.implement._checkout_wip_branch") as mock_checkout, \
+             patch("clayde.tasks.implement.DATA_DIR", Path("/tmp/test-data")):
+            mock_fc.return_value.body = "plan text"
+            mock_fi.return_value.title = "Test"
+            run("https://github.com/o/r/issues/1")
+
+        mock_checkout.assert_called_once_with("/tmp/repo", "clayde/issue-1-fix")
+
+
+class TestCheckoutWipBranch:
+    def test_checks_out_local_branch(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            if cmd == ["git", "branch", "--list", "clayde/issue-1"]:
+                result.stdout = "  clayde/issue-1\n"
+            else:
+                result.stdout = ""
+            return result
+
+        with patch("clayde.tasks.implement.subprocess.run", side_effect=fake_run):
+            _checkout_wip_branch("/repo", "clayde/issue-1")
+
+        cmd_strs = [" ".join(c) for c in calls]
+        assert any("checkout clayde/issue-1" in s for s in cmd_strs)
+
+    def test_checks_out_remote_branch(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            if cmd == ["git", "branch", "--list", "clayde/issue-1"]:
+                result.stdout = ""  # not local
+            elif "ls-remote" in cmd:
+                result.stdout = "abc123\trefs/heads/clayde/issue-1\n"
+            else:
+                result.stdout = ""
+            return result
+
+        with patch("clayde.tasks.implement.subprocess.run", side_effect=fake_run):
+            _checkout_wip_branch("/repo", "clayde/issue-1")
+
+        cmd_strs = [" ".join(c) for c in calls]
+        assert any("checkout -b clayde/issue-1 origin/clayde/issue-1" in s for s in cmd_strs)
+
+    def test_no_branch_found_does_nothing(self):
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            return result
+
+        with patch("clayde.tasks.implement.subprocess.run", side_effect=fake_run):
+            _checkout_wip_branch("/repo", "clayde/issue-1")  # Should not raise


### PR DESCRIPTION
## Summary
- **WIP commit on rate limit**: When `invoke_claude` hits a rate limit, uncommitted changes are committed and pushed to the working branch before raising `UsageLimitError`
- **Conversation persistence**: The full message history is saved to `DATA_DIR/conversations/` on interruption and resumed on retry, so Claude continues where it left off instead of starting from scratch
- **Branch checkout on resume**: Interrupted implementations check out the existing WIP branch instead of resetting to main
- Conversation files are preserved after completion for manual review

## Test plan
- [x] `_commit_wip` commits and pushes changes, skips when no changes, never raises
- [x] Conversation save/load round-trips correctly including pydantic content blocks
- [x] Rate limit (429 and 529) triggers both WIP commit and conversation save
- [x] Resume loads saved conversation and appends continuation message
- [x] `_checkout_wip_branch` handles local branch, remote branch, and missing branch
- [x] Conversation path and branch name are wired through from `implement.run()`
- [x] Conversation file is preserved (not deleted) on success
- [x] All 129 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)