### PR TITLE
Fix sub-issue relationship check failing on Github.auth

### DIFF
--- a/src/clayde/github.py
+++ b/src/clayde/github.py
@@ -6,6 +6,8 @@ import re
 import requests
 from github import Github, GithubException
 
+from clayde.config import get_settings
+
 log = logging.getLogger("clayde.github")
 
 
@@ -102,7 +104,7 @@ def is_blocked(g: Github, owner: str, repo: str, number: int) -> bool:
 
     # Check explicit sub-issue relationships via timeline events
     try:
-        token = g.auth.token if hasattr(g.auth, "token") else None
+        token = get_settings().github_token
         if token:
             if _has_blocking_sub_issue_parents(token, owner, repo, number):
                 return True

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -248,9 +248,10 @@ class TestIsBlocked:
         issue = MagicMock()
         issue.body = "Normal issue"
         g.get_repo.return_value.get_issue.return_value = issue
-        g.auth = MagicMock()
-        g.auth.token = "tok"
-        with patch("clayde.github._has_blocking_sub_issue_parents", return_value=True):
+        settings = MagicMock()
+        settings.github_token = "tok"
+        with patch("clayde.github._has_blocking_sub_issue_parents", return_value=True), \
+             patch("clayde.github.get_settings", return_value=settings):
             assert is_blocked(g, "o", "r", 1) is True
 
     def test_timeline_failure_does_not_block(self):
@@ -258,9 +259,10 @@ class TestIsBlocked:
         issue = MagicMock()
         issue.body = "Normal issue"
         g.get_repo.return_value.get_issue.return_value = issue
-        g.auth = MagicMock()
-        g.auth.token = "tok"
-        with patch("clayde.github._has_blocking_sub_issue_parents", side_effect=Exception("fail")):
+        settings = MagicMock()
+        settings.github_token = "tok"
+        with patch("clayde.github._has_blocking_sub_issue_parents", side_effect=Exception("fail")), \
+             patch("clayde.github.get_settings", return_value=settings):
             # Should not raise, and should not block
             assert is_blocked(g, "o", "r", 1) is False
 


### PR DESCRIPTION
## Summary
- PyGitHub's `Github` object doesn't expose `auth` as a public attribute, so `g.auth.token` always raised `AttributeError` and the sub-issue blocking check was silently skipped
- Use `get_settings().github_token` (top-level import) to get the token instead
- Updated tests to patch `get_settings` rather than mock `g.auth`

## Test plan
- [x] All 206 tests pass
- [x] Verified `Github` object lacks `auth` attribute in current PyGitHub version

🤖 Generated with [Claude Code](https://claude.com/claude-code)