### PR TITLE
Make plan prompts concise and human-readable with word limits

### DIFF
--- a/src/clayde/prompts/preliminary_plan.j2
+++ b/src/clayde/prompts/preliminary_plan.j2
@@ -19,7 +19,7 @@ Then produce a SHORT preliminary plan that includes:
 - Any clarifying questions you have
 - A rough scope estimate (small / medium / large)
 
-Keep this concise — this is just a preliminary overview for discussion, not the
-full implementation plan. That comes later after approval.
+HARD LIMIT: 200 words or fewer. This is just a preliminary overview for
+discussion, not the full implementation plan. That comes later after approval.
 
 Output ONLY the preliminary plan in markdown format. No preamble, no wrapping.

--- a/src/clayde/prompts/thorough_plan.j2
+++ b/src/clayde/prompts/thorough_plan.j2
@@ -1,4 +1,4 @@
-Research the following GitHub issue and produce a detailed implementation plan.
+Research the following GitHub issue and produce an implementation plan.
 
 ISSUE #{{ number }}: {{ title }}
 REPO: {{ owner }}/{{ repo }}
@@ -17,12 +17,22 @@ REPOSITORY ON DISK: {{ repo_path }}
 
 Explore the repository to understand the codebase relevant to this issue.
 Pay special attention to agents.md files throughout.
-Then produce a thorough plan that includes:
+Then produce a plan that describes WHAT needs to change, not HOW to change it.
+The plan will be reviewed by a human, so prioritize clarity and readability.
+Use clear structure, short paragraphs, and plain language.
+
+The plan should include:
 - Summary of what needs to be done and why
-- Files to create or modify (with specific locations)
-- Implementation approach and key decisions
+- Which files and components are affected
+- Key design decisions (if any alternatives exist, state which you chose and why)
 - Edge cases and risks
 - How to verify the implementation is correct
+
+HARD LIMIT: The plan must be 500 words or fewer (excluding the branch name line).
+Do NOT include code snippets, exact code changes, step-by-step implementation
+instructions, or line-by-line diffs. The implementing model will read the codebase
+itself — your job is to describe the desired outcome clearly, not to dictate the
+implementation.
 
 At the end of your plan, include a branch name suggestion on its own line in
 exactly this format:

--- a/tests/test_tasks_plan.py
+++ b/tests/test_tasks_plan.py
@@ -115,7 +115,7 @@ class TestBuildThoroughPrompt:
             )
         assert "my preliminary plan" in prompt
         assert "discussion text" in prompt
-        assert "thorough" in prompt.lower() or "detailed" in prompt.lower()
+        assert "implementation plan" in prompt.lower()
 
 
 class TestBuildUpdatePrompt:


### PR DESCRIPTION
## Summary
- Refocus thorough plan prompt on **what** needs to change rather than **how**, removing code snippets and step-by-step instructions that were overwhelming the implementing model
- Add readability/clarity guidance since plans are reviewed by humans
- Enforce hard word limits: 200 words for preliminary plans, 500 words for thorough plans

## Test plan
- [x] All 245 tests pass
- [ ] Verify next Clayde plan cycle produces shorter, clearer plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)