### PR TITLE
Include issue/PR titles in logs and status output

### DIFF
--- a/src/clayde/cli.py
+++ b/src/clayde/cli.py
@@ -14,7 +14,15 @@ def cmd_status(args: argparse.Namespace) -> None:
         return
     for url, entry in issues.items():
         status = entry.get("status", "(unknown)")
-        print(f"{status:35} {url}")
+        number = entry.get("number", "?")
+        owner = entry.get("owner", "")
+        repo = entry.get("repo", "")
+        repo_ref = f"{owner}/{repo}" if owner and repo else url
+        title = entry.get("pr_title") or entry.get("issue_title") or "(title unknown)"
+        pr_url = entry.get("pr_url")
+        print(f"{status:<28} #{number}  {title}  ({repo_ref})")
+        if pr_url:
+            print(f"{'':28} └─ PR: {pr_url}")
 
 
 def cmd_clear(args: argparse.Namespace) -> None:

--- a/src/clayde/config.py
+++ b/src/clayde/config.py
@@ -77,10 +77,7 @@ def setup_logging() -> None:
     log_file = DATA_DIR / "logs" / "agent.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
     handler = logging.FileHandler(log_file)
-    handler.setFormatter(logging.Formatter(
-        "[%(asctime)s] [%(name)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    ))
+    handler.setFormatter(logging.Formatter("%(message)s"))
     root = logging.getLogger("clayde")
     root.setLevel(logging.INFO)
     root.addHandler(handler)

--- a/src/clayde/github.py
+++ b/src/clayde/github.py
@@ -176,3 +176,8 @@ def get_issue_author(g: Github, owner: str, repo: str, number: int) -> str:
     """Return the login of the issue author."""
     issue = _get_repo(g, owner, repo).get_issue(number)
     return issue.user.login
+
+
+def get_pr_title(g: Github, owner: str, repo: str, pr_number: int) -> str:
+    """Return the title of a pull request."""
+    return _get_repo(g, owner, repo).get_pull(pr_number).title

--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -17,6 +17,7 @@ import os
 import signal
 import sys
 import time
+from datetime import datetime
 
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
@@ -48,6 +49,19 @@ _STATUS_COMPAT = {
 }
 
 
+def _issue_label(issue_state: dict) -> str:
+    """Return '#N: title' for display in log lines.
+
+    In PR phases, prefers pr_title over issue_title.
+    Falls back to '#N (title unknown)' when no title is cached.
+    """
+    number = issue_state.get("number", "?")
+    title = issue_state.get("pr_title") or issue_state.get("issue_title")
+    if title:
+        return f"#{number}: {title}"
+    return f"#{number} (title unknown)"
+
+
 def _handle_new_issue(g: Github, issue: Issue, url: str) -> None:
     """Handle a newly assigned issue — check for visible content and blocked state."""
     tracer = get_tracer()
@@ -57,7 +71,7 @@ def _handle_new_issue(g: Github, issue: Issue, url: str) -> None:
         # Check if issue is blocked by another open issue
         try:
             if is_blocked(g, owner, repo, number):
-                log.info("Skipping issue %s — blocked by another open issue", url)
+                log.info("Skipping issue #%d: %s — blocked by another open issue", issue.number, issue.title)
                 span.set_attribute("issue.skipped", True)
                 span.set_attribute("issue.skip_reason", "blocked")
                 return
@@ -67,17 +81,17 @@ def _handle_new_issue(g: Github, issue: Issue, url: str) -> None:
         # Check if there is any visible content to work with
         comments = fetch_issue_comments(g, owner, repo, number)
         if not has_visible_content(issue, comments):
-            log.info("Skipping issue %s — no visible content (all filtered out)", url)
+            log.info("Skipping issue #%d: %s — no visible content (all filtered out)", issue.number, issue.title)
             span.set_attribute("issue.skipped", True)
             span.set_attribute("issue.skip_reason", "no_visible_content")
             return
 
-        log.info("New issue: %s — starting preliminary plan phase", url)
+        log.info("New issue #%d: %s — starting preliminary plan phase", issue.number, issue.title)
         try:
             plan.run_preliminary(url)
             span.set_attribute("issue.failed", False)
         except Exception as e:
-            log.error("ERROR in preliminary plan for %s: %s", url, e)
+            log.error("ERROR in preliminary plan for #%d: %s: %s", issue.number, issue.title, e)
             span.set_status(StatusCode.ERROR, str(e))
             span.record_exception(e)
             span.set_attribute("issue.failed", True)
@@ -104,36 +118,36 @@ def _handle_awaiting_approval(g: Github, url: str, issue_state: dict, *, phase: 
         span.set_attribute("issue.number", number)
 
         if not comment_id:
-            log.warning("No %s for %s — marking as failed", comment_id_key, url)
+            log.warning("No %s for %s — marking as failed", comment_id_key, _issue_label(issue_state))
             update_issue_state(url, {"status": IssueStatus.FAILED})
             return
 
         # Check for new visible comments first (plan update)
         if _has_new_comments(g, owner, repo, number, issue_state):
-            log.info("New comments on %s — updating %s plan", url, phase)
+            log.info("New comments on %s — updating %s plan", _issue_label(issue_state), phase)
             try:
                 plan.run_update(url, update_phase)
                 span.set_attribute("issue.action", "plan_update")
             except Exception as e:
-                log.error("ERROR updating %s plan for %s: %s", phase, url, e)
+                log.error("ERROR updating %s plan for %s: %s", phase, _issue_label(issue_state), e)
                 span.set_status(StatusCode.ERROR, str(e))
                 span.record_exception(e)
             return
 
         # Check for approval (👍 on plan comment)
         if is_plan_approved(g, owner, repo, number, comment_id):
-            log.info("%s plan approved: %s — running %s", phase.capitalize(), url, next_task_label)
+            log.info("%s plan approved: %s — running %s", phase.capitalize(), _issue_label(issue_state), next_task_label)
             try:
                 next_task(url)
                 span.set_attribute("issue.action", next_task_label)
             except Exception as e:
-                log.error("ERROR in %s for %s: %s", next_task_label, url, e)
+                log.error("ERROR in %s for %s: %s", next_task_label, _issue_label(issue_state), e)
                 span.set_status(StatusCode.ERROR, str(e))
                 span.record_exception(e)
                 update_issue_state(url, {"status": IssueStatus.FAILED})
             return
 
-        log.info("Issue %s awaiting %s approval", url, phase)
+        log.info("%s awaiting %s approval", _issue_label(issue_state), phase)
         span.set_attribute("issue.skipped", True)
         span.set_attribute("issue.skip_reason", "not_approved")
 
@@ -143,12 +157,12 @@ def _handle_pr_open(g: Github, url: str, issue_state: dict) -> None:
     tracer = get_tracer()
     with tracer.start_as_current_span("clayde.handle_pr_open", attributes={"issue.url": url}) as span:
         span.set_attribute("issue.number", issue_state.get("number", 0))
-        log.info("Checking for PR reviews on %s", url)
+        log.info("Checking for PR reviews on %s", _issue_label(issue_state))
         try:
             review.run(url)
             span.set_attribute("issue.failed", False)
         except Exception as e:
-            log.error("ERROR in review handling for %s: %s", url, e)
+            log.error("ERROR in review handling for %s: %s", _issue_label(issue_state), e)
             span.set_status(StatusCode.ERROR, str(e))
             span.record_exception(e)
             span.set_attribute("issue.failed", True)
@@ -160,7 +174,7 @@ def _handle_interrupted(url: str, issue_state: dict) -> None:
     tracer = get_tracer()
     phase = issue_state.get("interrupted_phase")
     with tracer.start_as_current_span("clayde.handle_interrupted", attributes={"issue.url": url, "issue.interrupted_phase": phase or "unknown"}) as span:
-        log.info("Retrying interrupted issue %s (phase: %s)", url, phase)
+        log.info("Retrying interrupted %s (phase: %s)", _issue_label(issue_state), phase)
 
         task_map = {
             IssueStatus.PRELIMINARY_PLANNING: plan.run_preliminary,
@@ -170,7 +184,7 @@ def _handle_interrupted(url: str, issue_state: dict) -> None:
         }
         task = task_map.get(phase)
         if task is None:
-            log.warning("Unknown interrupted_phase '%s' for %s — skipping", phase, url)
+            log.warning("Unknown interrupted_phase %r for %s — skipping", phase, _issue_label(issue_state))
             span.set_attribute("issue.skipped", True)
             span.set_attribute("issue.skip_reason", "unknown_phase")
             return
@@ -178,7 +192,7 @@ def _handle_interrupted(url: str, issue_state: dict) -> None:
             task(url)
             span.set_attribute("issue.failed", False)
         except Exception as e:
-            log.error("ERROR retrying interrupted issue %s: %s", url, e)
+            log.error("ERROR retrying interrupted %s: %s", _issue_label(issue_state), e)
             span.set_status(StatusCode.ERROR, str(e))
             span.record_exception(e)
             span.set_attribute("issue.failed", True)
@@ -199,7 +213,7 @@ def main():
     if not settings.enabled:
         sys.exit(0)
 
-    log.info("=== Starting Clayde Tick ===")
+    log.info("=== Starting Clayde Tick [%s] ===", datetime.now().strftime("%Y-%m-%d %H:%M"))
 
     os.environ["GH_TOKEN"] = settings.github_token
 
@@ -257,7 +271,7 @@ def main():
             elif status == IssueStatus.INTERRUPTED:
                 _handle_interrupted(url, issue_state)
             elif status == IssueStatus.FAILED:
-                log.info("Skipping failed issue: %s (clear state to retry)", url)
+                log.info("Skipping failed issue %s (clear state to retry)", _issue_label(issue_state))
 
         tick_span.set_attribute("issues.processed", processed)
 

--- a/src/clayde/tasks/implement.py
+++ b/src/clayde/tasks/implement.py
@@ -22,6 +22,7 @@ from clayde.github import (
     find_open_pr,
     get_default_branch,
     get_issue_author,
+    get_pr_title,
     parse_issue_url,
     parse_pr_url,
     post_comment,
@@ -55,7 +56,7 @@ def run(issue_url: str) -> None:
             _prepare_implementation_context(g, owner, repo, number, issue_url, issue_state, resumed)
         )
 
-        log.info("Invoking Claude for implementation of issue #%d", number)
+        log.info("Invoking Claude for implementation of #%d: %s", number, issue.title)
         try:
             result = invoke_claude(
                 prompt,
@@ -79,7 +80,7 @@ def run(issue_url: str) -> None:
         if pr_url:
             _assign_reviewer_and_finish(g, owner, repo, number, issue_url, pr_url, span, cost_eur=total_cost)
         else:
-            log.error("Implementation of #%d produced no PR", number)
+            log.error("Implementation of #%d: %s produced no PR", number, issue.title)
             log.error("Claude output (last 2000 chars): %s", (result.output or "")[-2000:])
             _handle_no_pr(g, owner, repo, number, issue_url, issue_state, span)
 
@@ -180,21 +181,34 @@ def _assign_reviewer_and_finish(g, owner, repo, number, issue_url, pr_url, span,
     """Post result, assign reviewer, set status to pr_open."""
     _post_result(g, owner, repo, number, pr_url, cost_eur=cost_eur)
 
+    _, _, pr_number = parse_pr_url(pr_url)
+
+    pr_title = None
+    try:
+        pr_title = get_pr_title(g, owner, repo, pr_number)
+    except Exception as e:
+        log.warning("Failed to fetch PR title for %s: %s", pr_url, e)
+
     try:
         issue_author = get_issue_author(g, owner, repo, number)
-        _, _, pr_number = parse_pr_url(pr_url)
         add_pr_reviewer(g, owner, repo, pr_number, issue_author)
     except Exception as e:
         log.warning("Failed to assign reviewer for PR %s: %s", pr_url, e)
 
-    update_issue_state(issue_url, {
+    state_update = {
         "status": IssueStatus.PR_OPEN,
         "pr_url": pr_url,
         "last_seen_review_id": 0,
-    })
+    }
+    if pr_title:
+        state_update["pr_title"] = pr_title
+
+    update_issue_state(issue_url, state_update)
     span.set_attribute("implement.status", "pr_open")
     span.set_attribute("implement.pr_url", pr_url)
-    log.info("Issue #%d PR open — monitoring for reviews: %s", number, pr_url)
+
+    display = f"#{number}: {pr_title}" if pr_title else f"#{number} (title unknown)"
+    log.info("Issue %s — PR open, monitoring for reviews: %s", display, pr_url)
 
 
 def _checkout_wip_branch(repo_path, branch_name: str) -> None:

--- a/src/clayde/tasks/plan.py
+++ b/src/clayde/tasks/plan.py
@@ -46,18 +46,18 @@ def run_preliminary(issue_url: str) -> None:
         span.set_attribute("issue.number", number)
         span.set_attribute("issue.owner", owner)
         span.set_attribute("issue.repo", repo)
+        issue = fetch_issue(g, owner, repo, number)
         update_issue_state(issue_url, {
             "status": IssueStatus.PRELIMINARY_PLANNING,
             "owner": owner, "repo": repo, "number": number,
+            "issue_title": issue.title,
         })
-
-        issue = fetch_issue(g, owner, repo, number)
         default_branch = get_default_branch(g, owner, repo)
         repo_path = ensure_repo(owner, repo, default_branch)
 
         prompt = _build_preliminary_prompt(g, issue, owner, repo, number, repo_path)
 
-        log.info("Invoking Claude for preliminary plan on issue #%d", number)
+        log.info("Invoking Claude for preliminary plan on #%d: %s", number, issue.title)
         try:
             result = invoke_claude(prompt, repo_path)
         except UsageLimitError as e:
@@ -75,14 +75,14 @@ def run_preliminary(issue_url: str) -> None:
         span.set_attribute("plan.output_length", len(plan_text))
 
         if not plan_text.strip():
-            log.error("Claude returned empty preliminary plan for issue #%d", number)
+            log.error("Claude returned empty preliminary plan for #%d: %s", number, issue.title)
             span.set_attribute("plan.status", "empty")
             update_issue_state(issue_url, {"status": IssueStatus.FAILED})
             return
 
         if len(plan_text.strip()) < 100:
-            log.warning("Claude returned very short preliminary plan for issue #%d (%d chars)",
-                        number, len(plan_text.strip()))
+            log.warning("Claude returned very short preliminary plan for #%d: %s (%d chars)",
+                        number, issue.title, len(plan_text.strip()))
             span.set_attribute("plan.status", "short")
             update_issue_state(issue_url, {
                 "status": IssueStatus.INTERRUPTED,
@@ -102,7 +102,7 @@ def run_preliminary(issue_url: str) -> None:
             "last_seen_comment_id": last_comment_id,
         })
         span.set_attribute("plan.status", "posted")
-        log.info("Preliminary plan posted for issue #%d (comment %s)", number, comment_id)
+        log.info("Preliminary plan posted for #%d: %s (comment %s)", number, issue.title, comment_id)
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +139,7 @@ def run_thorough(issue_url: str) -> None:
             preliminary_text, discussion_text,
         )
 
-        log.info("Invoking Claude for thorough plan on issue #%d", number)
+        log.info("Invoking Claude for thorough plan on #%d: %s", number, issue.title)
         try:
             result = invoke_claude(prompt, repo_path)
         except UsageLimitError as e:
@@ -157,14 +157,14 @@ def run_thorough(issue_url: str) -> None:
         span.set_attribute("plan.output_length", len(plan_text))
 
         if not plan_text.strip():
-            log.error("Claude returned empty thorough plan for issue #%d", number)
+            log.error("Claude returned empty thorough plan for #%d: %s", number, issue.title)
             span.set_attribute("plan.status", "empty")
             update_issue_state(issue_url, {"status": IssueStatus.FAILED})
             return
 
         if len(plan_text.strip()) < 200:
-            log.warning("Claude returned very short thorough plan for issue #%d (%d chars)",
-                        number, len(plan_text.strip()))
+            log.warning("Claude returned very short thorough plan for #%d: %s (%d chars)",
+                        number, issue.title, len(plan_text.strip()))
             span.set_attribute("plan.status", "short")
             update_issue_state(issue_url, {
                 "status": IssueStatus.INTERRUPTED,
@@ -184,7 +184,7 @@ def run_thorough(issue_url: str) -> None:
             "last_seen_comment_id": last_comment_id,
         })
         span.set_attribute("plan.status", "posted")
-        log.info("Thorough plan posted for issue #%d (comment %s)", number, comment_id)
+        log.info("Thorough plan posted for #%d: %s (comment %s)", number, issue.title, comment_id)
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ def run_update(issue_url: str, phase: str) -> None:
         new_comments = get_new_visible_comments(all_comments, last_seen)
 
         if not new_comments:
-            log.info("No new visible comments for issue #%d — skipping update", number)
+            log.info("No new visible comments for #%d: %s — skipping update", number, issue.title)
             return
 
         new_comments_text = "\n---\n".join(
@@ -246,7 +246,7 @@ def run_update(issue_url: str, phase: str) -> None:
             phase=phase,
         )
 
-        log.info("Invoking Claude for plan update on issue #%d (%s phase)", number, phase)
+        log.info("Invoking Claude for plan update on #%d: %s (%s phase)", number, issue.title, phase)
         try:
             result = invoke_claude(prompt, repo_path)
         except UsageLimitError as e:
@@ -267,7 +267,7 @@ def run_update(issue_url: str, phase: str) -> None:
         if updated_plan:
             # Edit the existing plan comment
             edit_comment(g, owner, repo, number, plan_comment_id, updated_plan)
-            log.info("Updated %s plan comment %d for issue #%d", phase, plan_comment_id, number)
+            log.info("Updated %s plan comment %d for #%d: %s", phase, plan_comment_id, number, issue.title)
 
         if summary:
             # Post a new comment with the change summary
@@ -283,7 +283,7 @@ def run_update(issue_url: str, phase: str) -> None:
             "last_seen_comment_id": last_comment_id,
         })
         span.set_attribute("plan.update_status", "updated")
-        log.info("Plan update complete for issue #%d", number)
+        log.info("Plan update complete for #%d: %s", number, issue.title)
 
 
 

--- a/src/clayde/tasks/review.py
+++ b/src/clayde/tasks/review.py
@@ -33,8 +33,11 @@ def run(issue_url: str) -> None:
         span.set_attribute("issue.owner", owner)
         span.set_attribute("issue.repo", repo)
 
+        _title = issue_state.get("pr_title") or issue_state.get("issue_title")
+        _display = f"#{number}: {_title}" if _title else f"#{number} (title unknown)"
+
         if not pr_url:
-            log.warning("No PR URL in state for issue #%d — skipping review", number)
+            log.warning("No PR URL in state for %s — skipping review", _display)
             return
 
         _, _, pr_number = parse_pr_url(pr_url)
@@ -50,7 +53,7 @@ def run(issue_url: str) -> None:
         ]
 
         if not new_reviews:
-            log.info("No new reviews on PR #%d for issue #%d", pr_number, number)
+            log.info("No new reviews on PR #%d for %s", pr_number, _display)
             return
 
         # Check if any new review has actual content (comments or body)
@@ -75,7 +78,7 @@ def run(issue_url: str) -> None:
             # Check if any review is an approval
             approved = any(r.state == "APPROVED" for r in new_reviews)
             if approved:
-                log.info("PR #%d approved for issue #%d — marking as done", pr_number, number)
+                log.info("PR #%d approved for %s — marking as done", pr_number, _display)
                 update_issue_state(issue_url, {"status": IssueStatus.DONE})
                 span.set_attribute("review.status", "approved")
             return
@@ -83,8 +86,8 @@ def run(issue_url: str) -> None:
         # Build review text for Claude
         review_text = _format_reviews(new_reviews, relevant_comments)
 
-        log.info("Addressing %d new review(s) on PR #%d for issue #%d",
-                 len(new_reviews), pr_number, number)
+        log.info("Addressing %d new review(s) on PR #%d for %s",
+                 len(new_reviews), pr_number, _display)
 
         update_issue_state(issue_url, {"status": IssueStatus.ADDRESSING_REVIEW})
 
@@ -131,7 +134,7 @@ def run(issue_url: str) -> None:
             "last_seen_review_id": max_review_id,
         })
         span.set_attribute("review.status", "addressed")
-        log.info("Review comments addressed for issue #%d", number)
+        log.info("Review comments addressed for %s", _display)
 
 
 def _format_reviews(reviews: list, review_comments: list) -> str:

--- a/tests/test_tasks_plan.py
+++ b/tests/test_tasks_plan.py
@@ -247,10 +247,13 @@ class TestRunPreliminary:
         mock_comment = MagicMock()
         mock_comment.id = 500
 
+        mock_issue = MagicMock()
+        mock_issue.title = "Test issue"
+
         with patch("clayde.tasks.plan.get_github_client") as mock_gc, \
              patch("clayde.tasks.plan.parse_issue_url", return_value=("o", "r", 1)), \
              patch("clayde.tasks.plan.update_issue_state") as mock_update, \
-             patch("clayde.tasks.plan.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.plan.fetch_issue", return_value=mock_issue) as mock_fi, \
              patch("clayde.tasks.plan.get_default_branch", return_value="main"), \
              patch("clayde.tasks.plan.ensure_repo", return_value="/tmp/repo"), \
              patch("clayde.tasks.plan._build_preliminary_prompt", return_value="prompt"), \
@@ -262,7 +265,8 @@ class TestRunPreliminary:
 
         calls = mock_update.call_args_list
         assert calls[0][0] == ("https://github.com/o/r/issues/1",
-                               {"status": "preliminary_planning", "owner": "o", "repo": "r", "number": 1})
+                               {"status": "preliminary_planning", "owner": "o", "repo": "r", "number": 1,
+                                "issue_title": "Test issue"})
         last = calls[-1][0][1]
         assert last["status"] == "awaiting_preliminary_approval"
         assert last["preliminary_comment_id"] == 999


### PR DESCRIPTION
## Summary
- Strip redundant `[timestamp] [module]` prefix from log formatter; tick banner now carries a human-readable timestamp instead
- All log lines include `#N: title` (issue or PR title) so the log is scannable at a glance
- `clayde-ctl status` shows title, repo reference, and PR URL inline instead of just the raw issue URL
- New `get_pr_title()` helper in `github.py`; `issue_title` and `pr_title` cached in state

## Test plan
- [x] All 245 existing tests pass (`uv run pytest`)
- [ ] After a live tick, verify `agent.log` lines show `#N: title` format
- [ ] Verify `clayde-ctl status` shows enriched output with titles and PR URLs

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)