### PR TITLE
Narrow CLI usage limit detection to avoid false positives

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -34,16 +34,12 @@ _MODEL_PRICING: dict[str, tuple[float, float]] = {
 # EUR/USD conversion rate — last updated: 2026-03
 _EUR_PER_USD = 0.92
 
-# Text patterns that indicate a usage/rate limit in CLI output.
+# Text patterns that indicate a usage/rate limit in CLI error output.
 _LIMIT_PATTERNS = [
     "usage limit",
     "rate limit",
     "session limit",
-    "claude code pro",
-    "you've reached",
-    "exceeded your",
     "hit your limit",
-    "resets at",
 ]
 
 
@@ -516,15 +512,15 @@ class CliBackend(ClaudeBackend):
             span.set_attribute("claude.timeout", False)
             span.set_attribute("claude.exit_code", result.returncode)
 
-            combined = (result.stdout or "") + (result.stderr or "")
-
             # Parse JSON output
             output_text = ""
             session_id = None
+            is_error = False
             try:
                 parsed = json.loads(result.stdout)
                 output_text = parsed.get("result", "")
                 session_id = parsed.get("session_id")
+                is_error = parsed.get("is_error", False)
             except (json.JSONDecodeError, TypeError):
                 # Fall back to raw stdout if JSON parsing fails
                 output_text = result.stdout or ""
@@ -533,15 +529,21 @@ class CliBackend(ClaudeBackend):
             if conversation_path and session_id:
                 self._save_session_id(conversation_path, session_id)
 
-            # Check for usage/rate limits
-            if _is_limit_error(combined):
-                log.error("Claude CLI usage limit detected")
-                if branch_name:
-                    commit_wip(repo_path, branch_name)
-                span.set_attribute("claude.usage_limit", True)
-                exc = UsageLimitError("Claude CLI usage limit hit")
-                span.record_exception(exc)
-                raise exc
+            # Check for usage/rate limits only when there's an error signal.
+            # Never scan the full stdout — it contains the LLM response which
+            # could legitimately mention "rate limit" etc.
+            if result.returncode != 0 or is_error:
+                error_text = result.stderr or ""
+                if is_error:
+                    error_text += " " + output_text
+                if _is_limit_error(error_text):
+                    log.error("Claude CLI usage limit detected")
+                    if branch_name:
+                        commit_wip(repo_path, branch_name)
+                    span.set_attribute("claude.usage_limit", True)
+                    exc = UsageLimitError("Claude CLI usage limit hit")
+                    span.record_exception(exc)
+                    raise exc
 
             if result.returncode != 0:
                 log.error("Claude CLI exited with code %d", result.returncode)
@@ -568,8 +570,15 @@ class CliBackend(ClaudeBackend):
                      "--no-session-persistence"],
                     env=_make_cli_env(), text=True, capture_output=True, timeout=60,
                 )
-                combined = (result.stdout or "") + (result.stderr or "")
-                if _is_limit_error(combined):
+                error_text = result.stderr or ""
+                if result.returncode != 0:
+                    try:
+                        parsed = json.loads(result.stdout)
+                        if parsed.get("is_error", False):
+                            error_text += " " + parsed.get("result", "")
+                    except (json.JSONDecodeError, TypeError):
+                        error_text += " " + (result.stdout or "")
+                if _is_limit_error(error_text):
                     span.set_attribute("claude.available", False)
                     return False
                 span.set_attribute("claude.available", True)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -588,6 +588,11 @@ class TestLimitPatterns:
     def test_no_false_positive(self):
         assert _is_limit_error("Here is the implementation") is False
 
+    def test_no_false_positive_generic_phrases(self):
+        assert _is_limit_error("you've reached the end of the file") is False
+        assert _is_limit_error("exceeded your expectations") is False
+        assert _is_limit_error("the counter resets at midnight") is False
+
 
 class TestMakeCliEnv:
     def test_removes_claudecode(self, monkeypatch):
@@ -673,8 +678,8 @@ class TestCliBackendInvoke:
     def test_limit_detection_raises(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
         mock_result = MagicMock()
-        mock_result.stdout = "You've reached your usage limit"
-        mock_result.stderr = ""
+        mock_result.stdout = "{}"
+        mock_result.stderr = "You've reached your usage limit"
         mock_result.returncode = 1
         backend = CliBackend()
 
@@ -686,6 +691,22 @@ class TestCliBackendInvoke:
             with pytest.raises(UsageLimitError):
                 backend.invoke("prompt", "/repo", branch_name="branch")
             mock_wip.assert_called_once_with("/repo", "branch")
+
+    def test_no_limit_detection_on_success(self, tmp_path):
+        """Successful invocations mentioning 'rate limit' in output should not raise."""
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        mock_result = MagicMock()
+        mock_result.stdout = self._cli_json_output("I added rate limit handling")
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        backend = CliBackend()
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
+            result = backend.invoke("prompt", "/repo")
+            assert result.output == "I added rate limit handling"
 
     def test_limit_saves_session_before_raising(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("identity")
@@ -755,8 +776,8 @@ class TestCliBackendIsAvailable:
 
     def test_unavailable_on_limit(self):
         mock_result = MagicMock()
-        mock_result.stdout = "You've reached your usage limit"
-        mock_result.stderr = ""
+        mock_result.stdout = "{}"
+        mock_result.stderr = "You've reached your usage limit"
         mock_result.returncode = 1
         backend = CliBackend()
 


### PR DESCRIPTION
## Summary
- Gate limit pattern matching on error signals only (non-zero exit code or `is_error` JSON field) — successful invocations are never scanned
- Only check stderr and JSON error result text, never the full LLM response in stdout
- Remove 4 overly generic patterns (`"claude code pro"`, `"you've reached"`, `"exceeded your"`, `"resets at"`) that could match normal English

## Test plan
- [x] All 247 existing tests pass
- [x] New test: successful invocation mentioning "rate limit" in output does NOT raise `UsageLimitError`
- [x] New test: removed generic phrases no longer trigger detection
- [x] Existing tests updated to reflect stderr-based detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)