### PR TITLE
Fix .claude directory permission error in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN mkdir -p /data/repos /data/logs && chown -R clayde:clayde /data
 
 # Switch to non-root user and configure git
 USER clayde
-RUN git config --global credential.helper '!gh auth git-credential' && \
+RUN mkdir -p /home/clayde/.claude && \
+    git config --global credential.helper '!gh auth git-credential' && \
     git config --global user.name "Clayde" && \
     git config --global user.email "clayde@vtettenborn.net"
 


### PR DESCRIPTION
## Summary
- Pre-create `/home/clayde/.claude/` as the `clayde` user in the Dockerfile so the Claude Code CLI can create `session-env/` at runtime
- Without this, Docker's bind mount of `.credentials.json` implicitly creates the parent directory as root, causing `EACCES: permission denied`

## Test plan
- [ ] Rebuild image and verify Claude Code CLI can run without permission errors
- [ ] Confirm `.credentials.json` mount still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)