### PR TITLE
Recover issues stuck in transient states after crash

### DIFF
--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -240,6 +240,30 @@ def main():
             provider.force_flush()
             return
 
+        # Recover issues stuck in transient states (e.g. from a crash/restart)
+        _TRANSIENT_STATES = {
+            IssueStatus.PRELIMINARY_PLANNING,
+            IssueStatus.PLANNING,
+            IssueStatus.IMPLEMENTING,
+            IssueStatus.ADDRESSING_REVIEW,
+        }
+        for url, ist in issues_state.items():
+            status = ist.get("status")
+            status = _STATUS_COMPAT.get(status, status)
+            if status in _TRANSIENT_STATES:
+                log.warning(
+                    "Recovering stuck %s (was %s → interrupted)",
+                    _issue_label(ist),
+                    status,
+                )
+                update_issue_state(
+                    url,
+                    {"status": IssueStatus.INTERRUPTED, "interrupted_phase": status},
+                )
+
+        # Reload state after recovery mutations
+        issues_state = load_state().get("issues", {})
+
         processed = 0
         for issue in assigned:
             url = issue.html_url
@@ -249,14 +273,7 @@ def main():
             # Backward compatibility
             status = _STATUS_COMPAT.get(status, status)
 
-            # Skip in-progress or completed states
-            if status in (
-                IssueStatus.DONE,
-                IssueStatus.PRELIMINARY_PLANNING,
-                IssueStatus.PLANNING,
-                IssueStatus.IMPLEMENTING,
-                IssueStatus.ADDRESSING_REVIEW,
-            ):
+            if status == IssueStatus.DONE:
                 continue
 
             processed += 1

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -135,6 +135,38 @@ class TestMain:
             main()
             mock_handle.assert_called_once()
 
+    @pytest.mark.parametrize("transient_status", [
+        "preliminary_planning",
+        "planning",
+        "implementing",
+        "addressing_review",
+    ])
+    def test_recovers_transient_state_to_interrupted(self, transient_status):
+        """Issues stuck in transient states are converted to interrupted."""
+        issue = MagicMock()
+        issue.html_url = "url1"
+        state = {"issues": {"url1": {"status": transient_status, "number": 1}}}
+        recovered_state = {"issues": {"url1": {
+            "status": "interrupted",
+            "interrupted_phase": transient_status,
+            "number": 1,
+        }}}
+        with patch("clayde.orchestrator.get_settings", return_value=_mock_settings(enabled=True)), \
+             patch("clayde.orchestrator.setup_logging"), \
+             patch("clayde.orchestrator.init_tracer"), \
+             patch("clayde.orchestrator.is_claude_available", return_value=True), \
+             patch("clayde.orchestrator.get_github_client"), \
+             patch("clayde.orchestrator.get_assigned_issues", return_value=[issue]), \
+             patch("clayde.orchestrator.load_state", side_effect=[state, recovered_state]), \
+             patch("clayde.orchestrator.update_issue_state") as mock_update, \
+             patch("clayde.orchestrator._handle_interrupted") as mock_handle:
+            main()
+            mock_update.assert_called_once_with(
+                "url1",
+                {"status": "interrupted", "interrupted_phase": transient_status},
+            )
+            mock_handle.assert_called_once()
+
     def test_backward_compat_awaiting_approval(self):
         """Old 'awaiting_approval' status maps to 'awaiting_plan_approval'."""
         issue = MagicMock()


### PR DESCRIPTION
## Summary
- If the process crashes mid-task, issues in transient states (`preliminary_planning`, `planning`, `implementing`, `addressing_review`) would get permanently stuck — the orchestrator skipped them every tick
- Now at the start of each tick, any issue in a transient state is converted to `interrupted` with the correct `interrupted_phase`, so the existing retry logic picks them up automatically
- Added parametrized tests covering all 4 transient states

## Test plan
- [x] All 251 tests pass (`uv run pytest`)
- [ ] Manual: set an issue to `implementing` in state.json, run `clayde-once`, verify it gets converted to `interrupted` and retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)