### PR TITLE
Fix stale CLI session recovery

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -509,6 +509,36 @@ class CliBackend(ClaudeBackend):
                 span.record_exception(exc)
                 raise exc
 
+            # Detect stale session ID and retry fresh
+            if (
+                result.returncode != 0
+                and "no conversation found with session id" in (result.stderr or "").lower()
+                and conversation_path
+            ):
+                log.warning("CLI session not found — deleting stale conversation file and retrying fresh")
+                conversation_path.unlink(missing_ok=True)
+                # Rebuild command without --resume
+                cmd = [
+                    cli_bin, "-p", prompt,
+                    "--append-system-prompt", identity,
+                    "--output-format", "json",
+                    "--dangerously-skip-permissions",
+                ]
+                span.set_attribute("claude.stale_session_retry", True)
+                try:
+                    result = subprocess.run(
+                        cmd, cwd=repo_path, env=_make_cli_env(),
+                        text=True, capture_output=True, timeout=timeout_s,
+                    )
+                except subprocess.TimeoutExpired:
+                    log.error("Claude CLI timed out after %ds (fresh retry)", timeout_s)
+                    if branch_name:
+                        commit_wip(repo_path, branch_name)
+                    span.set_attribute("claude.timeout", True)
+                    exc = UsageLimitError(f"Claude CLI timed out after {timeout_s}s")
+                    span.record_exception(exc)
+                    raise exc
+
             span.set_attribute("claude.timeout", False)
             span.set_attribute("claude.exit_code", result.returncode)
 

--- a/src/clayde/tasks/implement.py
+++ b/src/clayde/tasks/implement.py
@@ -35,6 +35,14 @@ from clayde.telemetry import get_tracer
 log = logging.getLogger("clayde.tasks.implement")
 
 
+def _delete_conversation_file(owner: str, repo: str, number: int) -> None:
+    """Remove the conversation file for an issue so stale sessions don't persist."""
+    path = DATA_DIR / "conversations" / f"{owner}__{repo}__issue-{number}.json"
+    if path.exists():
+        path.unlink()
+        log.info("Deleted conversation file %s", path)
+
+
 def run(issue_url: str) -> None:
     tracer = get_tracer()
     with tracer.start_as_current_span("clayde.task.implement") as span:
@@ -50,6 +58,9 @@ def run(issue_url: str) -> None:
 
         if resumed and _try_resume_from_existing_pr(g, owner, repo, number, issue_url, issue_state, span):
             return
+
+        if not resumed:
+            _delete_conversation_file(owner, repo, number)
 
         update_issue_state(issue_url, {"status": IssueStatus.IMPLEMENTING})
 
@@ -197,6 +208,7 @@ def _handle_no_pr(g, owner, repo, number, issue_url, issue_state, span) -> None:
     retry_count = issue_state.get("retry_count", 0) + 1
     if retry_count >= max_retries:
         log.error("Issue #%d failed after %d retries — giving up", number, retry_count)
+        _delete_conversation_file(owner, repo, number)
         post_comment(g, owner, repo, number,
                      "Implementation failed to produce a PR after multiple retries. "
                      "Marking as failed — manual intervention needed.")

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -760,6 +760,63 @@ class TestCliBackendInvoke:
 
         assert result.output == "plain text output"
 
+    def test_stale_session_retries_fresh(self, tmp_path):
+        """When CLI reports 'No conversation found', delete conv file and retry without --resume."""
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        conv_path = tmp_path / "conv.json"
+        conv_path.write_text(json.dumps({"session_id": "stale-session"}))
+
+        stale_result = MagicMock()
+        stale_result.returncode = 1
+        stale_result.stdout = ""
+        stale_result.stderr = "No conversation found with session ID: stale-session"
+
+        fresh_result = MagicMock()
+        fresh_result.returncode = 0
+        fresh_result.stdout = json.dumps({
+            "result": "fresh output",
+            "session_id": "new-session",
+        })
+        fresh_result.stderr = ""
+
+        backend = CliBackend()
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", side_effect=[stale_result, fresh_result]) as mock_run:
+            result = backend.invoke("prompt", str(tmp_path), conversation_path=conv_path)
+
+        assert result.output == "fresh output"
+        # First call should have --resume, second should not
+        first_cmd = mock_run.call_args_list[0][0][0]
+        second_cmd = mock_run.call_args_list[1][0][0]
+        assert "--resume" in first_cmd
+        assert "--resume" not in second_cmd
+        # Conv file should now have the new session ID
+        data = json.loads(conv_path.read_text())
+        assert data["session_id"] == "new-session"
+
+    def test_stale_session_no_conv_path_no_retry(self, tmp_path):
+        """Without a conversation_path, stale session error is not retried."""
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "No conversation found with session ID: stale-session"
+
+        backend = CliBackend()
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result) as mock_run:
+            result = backend.invoke("prompt", str(tmp_path))
+
+        # Should return empty output (no retry since no conversation_path)
+        assert result.output == ""
+        assert mock_run.call_count == 1
+
 
 class TestCliBackendIsAvailable:
     def test_available_on_success(self):

--- a/tests/test_tasks_implement.py
+++ b/tests/test_tasks_implement.py
@@ -413,3 +413,65 @@ class TestCheckoutWipBranch:
 
         with patch("clayde.tasks.implement.subprocess.run", side_effect=fake_run):
             _checkout_wip_branch("/repo", "clayde/issue-1")  # Should not raise
+
+
+class TestDeleteConversationFile:
+    def test_fresh_run_deletes_stale_conversation_file(self, tmp_path):
+        """When starting a fresh (non-resumed) implementation, stale conversation files are deleted."""
+        conv_dir = tmp_path / "conversations"
+        conv_dir.mkdir()
+        conv_file = conv_dir / "o__r__issue-1.json"
+        conv_file.write_text('{"session_id": "stale"}')
+
+        with patch("clayde.tasks.implement.get_github_client"), \
+             patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
+             patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100}), \
+             patch("clayde.tasks.implement.update_issue_state"), \
+             patch("clayde.tasks.implement.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.implement.get_default_branch", return_value="main"), \
+             patch("clayde.tasks.implement.ensure_repo", return_value="/tmp/repo"), \
+             patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
+             patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
+             patch("clayde.tasks.implement.filter_comments", return_value=[]), \
+             patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
+             patch("clayde.tasks.implement.invoke_claude", return_value=_make_result("done")), \
+             patch("clayde.tasks.implement.find_open_pr", return_value="https://github.com/o/r/pull/5"), \
+             patch("clayde.tasks.implement._assign_reviewer_and_finish"), \
+             patch("clayde.tasks.implement.pop_accumulated_cost", return_value=0.0), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
+            mock_fc.return_value.body = "plan text"
+            mock_fi.return_value.title = "Test"
+            run("https://github.com/o/r/issues/1")
+
+        assert not conv_file.exists()
+
+    def test_failed_after_retries_deletes_conversation_file(self, tmp_path):
+        """When giving up after max retries, the conversation file is cleaned up."""
+        conv_dir = tmp_path / "conversations"
+        conv_dir.mkdir()
+        conv_file = conv_dir / "o__r__issue-1.json"
+        conv_file.write_text('{"session_id": "stale"}')
+
+        with patch("clayde.tasks.implement.get_github_client"), \
+             patch("clayde.tasks.implement.parse_issue_url", return_value=("o", "r", 1)), \
+             patch("clayde.tasks.implement.get_issue_state", return_value={"plan_comment_id": 100, "retry_count": 2}), \
+             patch("clayde.tasks.implement.update_issue_state"), \
+             patch("clayde.tasks.implement.fetch_issue") as mock_fi, \
+             patch("clayde.tasks.implement.get_default_branch", return_value="main"), \
+             patch("clayde.tasks.implement.ensure_repo", return_value="/tmp/repo"), \
+             patch("clayde.tasks.implement.fetch_comment") as mock_fc, \
+             patch("clayde.tasks.implement.fetch_issue_comments", return_value=[]), \
+             patch("clayde.tasks.implement.filter_comments", return_value=[]), \
+             patch("clayde.tasks.implement._build_prompt", return_value="prompt"), \
+             patch("clayde.tasks.implement.invoke_claude", return_value=_make_result("done")), \
+             patch("clayde.tasks.implement.find_open_pr", return_value=None), \
+             patch("clayde.tasks.implement._ensure_branch_pushed", return_value=True), \
+             patch("clayde.tasks.implement.create_pull_request", side_effect=Exception("fail")), \
+             patch("clayde.tasks.implement.post_comment"), \
+             patch("clayde.tasks.implement.pop_accumulated_cost", return_value=0.0), \
+             patch("clayde.tasks.implement.DATA_DIR", tmp_path):
+            mock_fc.return_value.body = "plan text"
+            mock_fi.return_value.title = "Test"
+            run("https://github.com/o/r/issues/1")
+
+        assert not conv_file.exists()


### PR DESCRIPTION
## Summary

- When the CLI backend gets "No conversation found with session ID", it now deletes the stale conversation file and retries a fresh invocation instead of returning empty output
- Fresh (non-resumed) implementations delete any leftover conversation file before invoking Claude, preventing stale session IDs from a previous failed round
- Conversation files are cleaned up when giving up after max retries, so they don't persist into future attempts

## Context

Issue #34 failed 6 times (two full rounds of 3 retries each) because:
1. First attempt wrote code but couldn't commit/push due to a permission error
2. `ensure_repo()` wiped the uncommitted changes on retry
3. The conversation file with a now-stale session ID survived the state reset
4. Every subsequent attempt loaded the stale session, CLI returned "No conversation found", empty output, no PR

## Test plan

- [x] New test: stale session triggers fresh retry (CLI backend)
- [x] New test: no retry without conversation_path
- [x] New test: fresh run deletes stale conversation file
- [x] New test: failed after max retries deletes conversation file
- [x] All 255 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)