### PR TITLE
Detect 'Not logged in' in CliBackend.is_available()

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -601,14 +601,20 @@ class CliBackend(ClaudeBackend):
                     env=_make_cli_env(), text=True, capture_output=True, timeout=60,
                 )
                 error_text = result.stderr or ""
-                if result.returncode != 0:
-                    try:
-                        parsed = json.loads(result.stdout)
-                        if parsed.get("is_error", False):
-                            error_text += " " + parsed.get("result", "")
-                    except (json.JSONDecodeError, TypeError):
+                is_error = False
+                try:
+                    parsed = json.loads(result.stdout)
+                    is_error = parsed.get("is_error", False)
+                    if is_error:
+                        error_text += " " + parsed.get("result", "")
+                except (json.JSONDecodeError, TypeError):
+                    if result.returncode != 0:
                         error_text += " " + (result.stdout or "")
                 if _is_limit_error(error_text):
+                    span.set_attribute("claude.available", False)
+                    return False
+                if is_error and "not logged in" in error_text.lower():
+                    log.warning("Claude CLI is not logged in — marking unavailable")
                     span.set_attribute("claude.available", False)
                     return False
                 span.set_attribute("claude.available", True)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -843,6 +843,18 @@ class TestCliBackendIsAvailable:
              patch("clayde.claude.subprocess.run", return_value=mock_result):
             assert backend.is_available() is False
 
+    def test_unavailable_on_not_logged_in(self):
+        mock_result = MagicMock()
+        mock_result.stdout = '{"is_error": true, "result": "Not logged in \\u00b7 Please run /login"}'
+        mock_result.stderr = ""
+        mock_result.returncode = 1
+        backend = CliBackend()
+
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
+            assert backend.is_available() is False
+
     def test_available_on_exception(self):
         backend = CliBackend()
 


### PR DESCRIPTION
## Summary
- `is_available()` now always parses JSON from CLI stdout (not just on non-zero returncode) to detect `is_error: true` responses
- Returns `False` when the CLI reports "Not logged in", preventing the orchestrator from attempting work with expired OAuth credentials
- Adds test covering the not-logged-in detection

Closes #34

## Test plan
- [x] `uv run pytest tests/test_claude.py` — all 70 tests pass
- [ ] Verify on deployed instance with expired credentials that the orchestrator skips work instead of producing garbage

🤖 Generated with [Claude Code](https://claude.com/claude-code)