### PR TITLE
Fix #45: Skip thorogh plan for small issues

### DIFF
--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -108,8 +108,18 @@ def _handle_awaiting_approval(g: Github, url: str, issue_state: dict, *, phase: 
     """
     comment_id_key = "preliminary_comment_id" if phase == "preliminary" else "plan_comment_id"
     update_phase = phase
-    next_task = plan.run_thorough if phase == "preliminary" else implement.run
-    next_task_label = "thorough_plan" if phase == "preliminary" else "implement"
+    if phase == "preliminary":
+        # Small issues skip thorough planning and go straight to implementation.
+        size = issue_state.get("size", "large")
+        if size == "small":
+            next_task = implement.run
+            next_task_label = "implement"
+        else:
+            next_task = plan.run_thorough
+            next_task_label = "thorough_plan"
+    else:
+        next_task = implement.run
+        next_task_label = "implement"
 
     tracer = get_tracer()
     with tracer.start_as_current_span(f"clayde.handle_awaiting_{phase}_approval", attributes={"issue.url": url}) as span:

--- a/src/clayde/prompts/preliminary_plan.j2
+++ b/src/clayde/prompts/preliminary_plan.j2
@@ -17,11 +17,19 @@ Pay special attention to agents.md files throughout.
 Then produce a SHORT preliminary plan that includes:
 - A brief overview of your approach (a few paragraphs, NOT an exhaustive plan)
 - Any clarifying questions you have
-- A rough scope estimate (small / medium / large)
 
 HARD LIMIT: 200 words or fewer. This is just a preliminary overview for
-discussion, not the full implementation plan. That comes later after approval.
+discussion, not the full implementation plan. That comes later after approval
+(for large issues).
+
+Also determine:
+- `size`: Classify the issue as `small` (roughly 1–5 files, mechanical or
+  well-scoped changes, no architectural decisions) or `large` (broader scope,
+  multiple components, significant design choices). When in doubt, prefer `large`.
+- `branch_name`: Choose a branch name in the format
+  `clayde/issue-{{ number }}-<slug>` where `<slug>` is a 1-to-3 word lowercase
+  hyphenated description (e.g. `clayde/issue-{{ number }}-better-branch-naming`).
 
 Output ONLY a JSON object with the following structure. No preamble, no markdown wrapping.
 
-{"plan": "<preliminary plan text in markdown>"}
+{"plan": "<preliminary plan text in markdown>", "size": "small|large", "branch_name": "clayde/issue-{{ number }}-<slug>"}

--- a/src/clayde/prompts/thorough_plan.j2
+++ b/src/clayde/prompts/thorough_plan.j2
@@ -28,7 +28,7 @@ The plan should include:
 - Edge cases and risks
 - How to verify the implementation is correct
 
-HARD LIMIT: The plan must be 500 words or fewer (excluding the branch name).
+HARD LIMIT: The plan must be 500 words or fewer.
 Do NOT include code snippets, exact code changes, step-by-step implementation
 instructions, or line-by-line diffs. The implementing model will read the codebase
 itself — your job is to describe the desired outcome clearly, not to dictate the
@@ -37,10 +37,6 @@ implementation.
 If anything is ambiguous or you need clarification, include your questions
 at the end under a "Questions" section.
 
-The branch name must be `clayde/issue-{{ number }}-<slug>` where `<slug>` is a
-1-to-3 word lowercase hyphenated description of the issue
-(e.g., `clayde/issue-13-better-branch-naming`).
-
 Output ONLY a JSON object with the following structure. No preamble, no markdown wrapping.
 
-{"plan": "<implementation plan in markdown>", "branch_name": "clayde/issue-{{ number }}-<slug>"}
+{"plan": "<implementation plan in markdown>"}

--- a/src/clayde/responses.py
+++ b/src/clayde/responses.py
@@ -2,17 +2,19 @@
 
 import json
 import re
+from typing import Literal
 
 from pydantic import BaseModel, ValidationError
 
 
 class PreliminaryPlanResponse(BaseModel):
     plan: str
+    size: Literal["small", "large"]
+    branch_name: str
 
 
 class ThoroughPlanResponse(BaseModel):
     plan: str
-    branch_name: str
 
 
 class UpdatePlanResponse(BaseModel):

--- a/src/clayde/tasks/plan.py
+++ b/src/clayde/tasks/plan.py
@@ -94,6 +94,8 @@ def run_preliminary(issue_url: str) -> None:
             return
 
         plan_text = parsed.plan
+        size = parsed.size
+        branch_name = parsed.branch_name
 
         if len(plan_text.strip()) < 100:
             log.warning("Claude returned very short preliminary plan for #%d: %s (%d chars)",
@@ -105,7 +107,7 @@ def run_preliminary(issue_url: str) -> None:
             })
             return
 
-        comment_id = _post_preliminary_comment(g, owner, repo, number, plan_text, total_cost)
+        comment_id = _post_preliminary_comment(g, owner, repo, number, plan_text, total_cost, size=size)
 
         # Track the last seen comment so we can detect new ones later
         all_comments = fetch_issue_comments(g, owner, repo, number)
@@ -115,6 +117,8 @@ def run_preliminary(issue_url: str) -> None:
             "status": IssueStatus.AWAITING_PRELIMINARY_APPROVAL,
             "preliminary_comment_id": comment_id,
             "last_seen_comment_id": last_comment_id,
+            "size": size,
+            "branch_name": branch_name,
         })
         span.set_attribute("plan.status", "posted")
         log.info("[%s: %s] Preliminary plan posted (comment %s)", issue_ref(owner, repo, number), issue.title, comment_id)
@@ -186,7 +190,6 @@ def run_thorough(issue_url: str) -> None:
             return
 
         plan_text = parsed.plan
-        branch_name = parsed.branch_name
 
         if len(plan_text.strip()) < 200:
             log.warning("Claude returned very short thorough plan for #%d: %s (%d chars)",
@@ -208,7 +211,6 @@ def run_thorough(issue_url: str) -> None:
             "status": IssueStatus.AWAITING_PLAN_APPROVAL,
             "plan_comment_id": comment_id,
             "last_seen_comment_id": last_comment_id,
-            "branch_name": branch_name,
         })
         span.set_attribute("plan.status", "posted")
         log.info("[%s: %s] Thorough plan posted (comment %s)", issue_ref(owner, repo, number), issue.title, comment_id)
@@ -398,13 +400,17 @@ def _build_update_prompt(number: int, title: str, owner: str, repo: str, body: s
 # ---------------------------------------------------------------------------
 
 def _post_preliminary_comment(g, owner: str, repo: str, number: int, plan_text: str,
-                              cost_eur: float = 0.0) -> int:
+                              cost_eur: float = 0.0, *, size: str = "large") -> int:
+    if size == "small":
+        next_step = "proceed directly to implementation"
+    else:
+        next_step = "proceed to a thorough implementation plan"
     comment_body = (
         f"## Preliminary Plan\n\n"
         f"{plan_text}\n\n"
         f"---\n"
-        f"*React with \U0001f44d to approve this preliminary plan and proceed "
-        f"to a thorough implementation plan.*"
+        f"*This looks like a **{size}** issue. "
+        f"React with \U0001f44d to approve this preliminary plan and {next_step}.*"
         f"{format_cost_line(cost_eur)}"
     )
     return post_comment(g, owner, repo, number, comment_body)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -279,6 +279,40 @@ class TestHandleAwaitingPreliminary:
             _handle_awaiting_approval(g, "url", entry, phase="preliminary")
             mock_plan.run_update.assert_called_once_with("url", "preliminary")
 
+    def test_runs_implement_directly_when_small_and_approved(self):
+        g = MagicMock()
+        entry = {"owner": "o", "repo": "r", "number": 1, "preliminary_comment_id": 100, "size": "small"}
+        with patch("clayde.orchestrator._has_new_comments", return_value=False), \
+             patch("clayde.orchestrator.is_plan_approved", return_value=True), \
+             patch("clayde.orchestrator.plan") as mock_plan, \
+             patch("clayde.orchestrator.implement") as mock_impl:
+            _handle_awaiting_approval(g, "url", entry, phase="preliminary")
+            mock_plan.run_thorough.assert_not_called()
+            mock_impl.run.assert_called_once_with("url")
+
+    def test_runs_thorough_when_large_and_approved(self):
+        g = MagicMock()
+        entry = {"owner": "o", "repo": "r", "number": 1, "preliminary_comment_id": 100, "size": "large"}
+        with patch("clayde.orchestrator._has_new_comments", return_value=False), \
+             patch("clayde.orchestrator.is_plan_approved", return_value=True), \
+             patch("clayde.orchestrator.plan") as mock_plan, \
+             patch("clayde.orchestrator.implement") as mock_impl:
+            _handle_awaiting_approval(g, "url", entry, phase="preliminary")
+            mock_plan.run_thorough.assert_called_once_with("url")
+            mock_impl.run.assert_not_called()
+
+    def test_defaults_to_large_when_size_absent(self):
+        """In-flight issues without size in state default to large behavior."""
+        g = MagicMock()
+        entry = {"owner": "o", "repo": "r", "number": 1, "preliminary_comment_id": 100}
+        with patch("clayde.orchestrator._has_new_comments", return_value=False), \
+             patch("clayde.orchestrator.is_plan_approved", return_value=True), \
+             patch("clayde.orchestrator.plan") as mock_plan, \
+             patch("clayde.orchestrator.implement") as mock_impl:
+            _handle_awaiting_approval(g, "url", entry, phase="preliminary")
+            mock_plan.run_thorough.assert_called_once_with("url")
+            mock_impl.run.assert_not_called()
+
     def test_sets_failed_on_thorough_exception(self):
         g = MagicMock()
         entry = {"owner": "o", "repo": "r", "number": 1, "preliminary_comment_id": 100}

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -40,17 +40,23 @@ class TestStripCodeFences:
 
 class TestParseResponse:
     def test_parses_preliminary_plan(self):
-        text = '{"plan": "My plan here"}'
+        text = '{"plan": "My plan here", "size": "small", "branch_name": "clayde/issue-1-fix"}'
         result = parse_response(text, PreliminaryPlanResponse)
         assert isinstance(result, PreliminaryPlanResponse)
         assert result.plan == "My plan here"
+        assert result.size == "small"
+        assert result.branch_name == "clayde/issue-1-fix"
+
+    def test_parses_preliminary_plan_large(self):
+        text = '{"plan": "Big plan", "size": "large", "branch_name": "clayde/issue-2-big-feature"}'
+        result = parse_response(text, PreliminaryPlanResponse)
+        assert result.size == "large"
 
     def test_parses_thorough_plan(self):
-        text = '{"plan": "Thorough plan", "branch_name": "clayde/issue-5-fix-bug"}'
+        text = '{"plan": "Thorough plan"}'
         result = parse_response(text, ThoroughPlanResponse)
         assert isinstance(result, ThoroughPlanResponse)
         assert result.plan == "Thorough plan"
-        assert result.branch_name == "clayde/issue-5-fix-bug"
 
     def test_parses_update_plan(self):
         text = '{"summary": "Changed X", "updated_plan": "Updated plan"}'
@@ -72,7 +78,7 @@ class TestParseResponse:
         assert result.summary == "Fixed the typo"
 
     def test_strips_code_fences_before_parsing(self):
-        text = '```json\n{"plan": "My plan"}\n```'
+        text = '```json\n{"plan": "My plan", "size": "small", "branch_name": "clayde/issue-1-fix"}\n```'
         result = parse_response(text, PreliminaryPlanResponse)
         assert result.plan == "My plan"
 
@@ -81,10 +87,10 @@ class TestParseResponse:
             parse_response("this is not json", PreliminaryPlanResponse)
 
     def test_missing_required_field_raises_value_error(self):
-        # ThoroughPlanResponse requires both plan and branch_name
-        text = '{"plan": "only plan, no branch_name"}'
+        # PreliminaryPlanResponse requires plan, size, and branch_name
+        text = '{"plan": "only plan, no size or branch_name"}'
         with pytest.raises(ValueError, match="failed validation"):
-            parse_response(text, ThoroughPlanResponse)
+            parse_response(text, PreliminaryPlanResponse)
 
     def test_wrong_type_raises_value_error(self):
         text = '{"plan": 123}'  # plan should be a string
@@ -96,13 +102,13 @@ class TestParseResponse:
             parse_response("", PreliminaryPlanResponse)
 
     def test_extra_fields_are_ignored(self):
-        text = '{"plan": "My plan", "extra_field": "ignored"}'
+        text = '{"plan": "My plan", "size": "small", "branch_name": "clayde/issue-1-fix", "extra_field": "ignored"}'
         result = parse_response(text, PreliminaryPlanResponse)
         assert result.plan == "My plan"
 
     def test_multiline_plan_preserved(self):
         import json
         plan_content = "## Plan\n\nStep 1\nStep 2"
-        text = json.dumps({"plan": plan_content})
+        text = json.dumps({"plan": plan_content, "size": "large", "branch_name": "clayde/issue-1-fix"})
         result = parse_response(text, PreliminaryPlanResponse)
         assert result.plan == plan_content

--- a/tests/test_tasks_plan.py
+++ b/tests/test_tasks_plan.py
@@ -148,20 +148,33 @@ class TestBuildUpdatePrompt:
 
 
 class TestPostPreliminaryComment:
-    def test_posts_formatted_comment(self):
+    def test_posts_formatted_comment_large(self):
         g = MagicMock()
         mock_comment = MagicMock()
         mock_comment.id = 555
         g.get_repo.return_value.get_issue.return_value.create_comment.return_value = mock_comment
 
-        result = _post_preliminary_comment(g, "owner", "repo", 1, "My preliminary plan")
+        result = _post_preliminary_comment(g, "owner", "repo", 1, "My preliminary plan", size="large")
         assert result == 555
         posted_body = g.get_repo.return_value.get_issue.return_value.create_comment.call_args[0][0]
         assert "## Preliminary Plan" in posted_body
         assert "My preliminary plan" in posted_body
         assert "\U0001f44d" in posted_body
-        assert "preliminary" in posted_body.lower()
+        assert "large" in posted_body
+        assert "thorough implementation plan" in posted_body
         assert "💸" not in posted_body  # no cost line when cost is 0
+
+    def test_posts_formatted_comment_small(self):
+        g = MagicMock()
+        mock_comment = MagicMock()
+        mock_comment.id = 556
+        g.get_repo.return_value.get_issue.return_value.create_comment.return_value = mock_comment
+
+        result = _post_preliminary_comment(g, "owner", "repo", 1, "My small plan", size="small")
+        assert result == 556
+        posted_body = g.get_repo.return_value.get_issue.return_value.create_comment.call_args[0][0]
+        assert "small" in posted_body
+        assert "directly to implementation" in posted_body
 
     def test_posts_with_cost(self):
         g = MagicMock()
@@ -238,7 +251,8 @@ class TestRunPreliminary:
              patch("clayde.tasks.plan.get_default_branch", return_value="main"), \
              patch("clayde.tasks.plan.ensure_repo", return_value="/tmp/repo"), \
              patch("clayde.tasks.plan._build_preliminary_prompt", return_value="prompt"), \
-             patch("clayde.tasks.plan.invoke_claude", return_value=_make_result('{"plan": "' + "x" * 150 + '"}', cost_eur=1.00)), \
+             patch("clayde.tasks.plan.invoke_claude", return_value=_make_result(
+                 '{"plan": "' + "x" * 150 + '", "size": "large", "branch_name": "clayde/issue-1-fix"}', cost_eur=1.00)), \
              patch("clayde.tasks.plan._post_preliminary_comment", return_value=999) as mock_post, \
              patch("clayde.tasks.plan.fetch_issue_comments", return_value=[mock_comment]), \
              patch("clayde.tasks.plan.pop_accumulated_cost", return_value=0.0):
@@ -252,6 +266,8 @@ class TestRunPreliminary:
         assert last["status"] == "awaiting_preliminary_approval"
         assert last["preliminary_comment_id"] == 999
         assert last["last_seen_comment_id"] == 500
+        assert last["size"] == "large"
+        assert last["branch_name"] == "clayde/issue-1-fix"
         # Cost is passed to the comment helper
         mock_post.assert_called_once()
         assert mock_post.call_args[0][4] == "x" * 150
@@ -317,7 +333,8 @@ class TestRunPreliminary:
              patch("clayde.tasks.plan.get_default_branch", return_value="main"), \
              patch("clayde.tasks.plan.ensure_repo", return_value="/tmp/repo"), \
              patch("clayde.tasks.plan._build_preliminary_prompt", return_value="prompt"), \
-             patch("clayde.tasks.plan.invoke_claude", return_value=_make_result('{"plan": "' + "x" * 150 + '"}', cost_eur=1.00)), \
+             patch("clayde.tasks.plan.invoke_claude", return_value=_make_result(
+                 '{"plan": "' + "x" * 150 + '", "size": "small", "branch_name": "clayde/issue-1-fix"}', cost_eur=1.00)), \
              patch("clayde.tasks.plan._post_preliminary_comment", return_value=999) as mock_post, \
              patch("clayde.tasks.plan.fetch_issue_comments", return_value=[mock_comment]), \
              patch("clayde.tasks.plan.pop_accumulated_cost", return_value=2.00):
@@ -344,7 +361,7 @@ class TestRunThorough:
              patch("clayde.tasks.plan.filter_comments", return_value=[]), \
              patch("clayde.tasks.plan._build_thorough_prompt", return_value="prompt"), \
              patch("clayde.tasks.plan.invoke_claude", return_value=_make_result(
-                 '{"plan": "' + "x" * 250 + '", "branch_name": "clayde/issue-1-fix"}', cost_eur=2.00)), \
+                 '{"plan": "' + "x" * 250 + '"}', cost_eur=2.00)), \
              patch("clayde.tasks.plan._post_thorough_plan_comment", return_value=888) as mock_post, \
              patch("clayde.tasks.plan.pop_accumulated_cost", return_value=0.0):
             mock_fc.return_value.body = "preliminary plan"
@@ -356,7 +373,7 @@ class TestRunThorough:
         last = calls[-1][0][1]
         assert last["status"] == "awaiting_plan_approval"
         assert last["plan_comment_id"] == 888
-        assert last["branch_name"] == "clayde/issue-1-fix"
+        assert "branch_name" not in last
         # Cost is passed
         assert mock_post.call_args[0][5] == 2.00
 


### PR DESCRIPTION
Closes #45

Added size classification (small/large) and branch_name to PreliminaryPlanResponse. Updated preliminary_plan.j2 to request both fields from Claude. Removed branch_name from ThoroughPlanResponse and thorough_plan.j2. In run_preliminary(), size and branch_name are now stored in issue state and the comment footer reflects the size. In the orchestrator, small issues skip thorough planning and go directly to implementation after preliminary plan approval, with absent size defaulting to large for backward compatibility.