### PR TITLE
Fix #58: Reliably run tests after implementation

### DIFF
--- a/src/clayde/prompts/address_review.j2
+++ b/src/clayde/prompts/address_review.j2
@@ -18,7 +18,9 @@ Steps:
 1. Check out the branch: git checkout {{ branch_name }} && git pull origin {{ branch_name }}
 2. Read and understand each review comment
 3. Make the requested changes
-4. Run tests if applicable
+4. Run tests if a test command is discoverable (check CLAUDE.md, README, Makefile, package.json, pyproject.toml, justfile):
+   - If no test runner is discoverable, skip this step.
+   - If a test suite exists: ensure all tests pass after your changes (pre-existing failures are exempt). Do NOT commit if your changes introduced new test failures.
 5. Commit with a clear message referencing the review, e.g.: "Address review: <summary>"
 6. Push: git push origin {{ branch_name }}
 

--- a/src/clayde/prompts/implement.j2
+++ b/src/clayde/prompts/implement.j2
@@ -18,7 +18,9 @@ Steps:
 2. Create or switch to branch: git checkout -b {{ branch_name }} (or git checkout {{ branch_name }} if it exists)
 3. Implement the plan carefully, following existing code style and paying attention to agents.md files if they exist
 4. Write or update tests if applicable
-5. Run tests if a test command is discoverable (check CLAUDE.md, README, Makefile, package.json, pyproject.toml, justfile)
+5. Run tests if a test command is discoverable (check CLAUDE.md, README, Makefile, package.json, pyproject.toml, justfile):
+   - If no test runner is discoverable, skip this step.
+   - If a test suite exists: first note any pre-existing failures (run tests on the base branch before your changes if needed), then ensure all tests pass after your changes (pre-existing failures are exempt). If there are pre-existing failures, you MUST mention them in your PR summary. Do NOT commit if your changes introduced new test failures.
 6. Review your own changes for correctness, edge cases, and style and run "just cleanup" if it exists before committing
 7. Commit with a clear message, e.g.: "Fix #{{ number }}: <summary>"
 8. Push: git push origin {{ branch_name }}


### PR DESCRIPTION
Closes #58

Updated implement.j2 and address_review.j2 to make test execution mandatory when a test suite is discoverable. If a test runner exists, tests must pass before committing (pre-existing failures are exempt but must be mentioned in the PR summary). If no test runner is discoverable, the step is skipped. All 284 existing tests pass.