### PR TITLE
Fix #60: Automatically pull and start a new version of Clayde as it becomes available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,12 @@ services:
       - ./data:/data
       # Mount Claude CLI OAuth credentials (required when CLAYDE_CLAUDE_BACKEND=cli)
       - ~/.claude/.credentials.json:/home/clayde/.claude/.credentials.json
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 --cleanup --label-enable


### PR DESCRIPTION
Closes #60

Added Watchtower sidecar service to docker-compose.yml. It polls the container registry every 5 minutes (--interval 300), automatically pulls and restarts the clayde container when a new image is available, cleans up old images (--cleanup), and uses label-based filtering (--label-enable) with com.centurylinklabs.watchtower.enable=true on the clayde service for future-proofing.