### PR TITLE
Fix #64: CLI backend: auth errors surface as misleading pydantic parse failure

### DIFF
--- a/src/clayde/claude.py
+++ b/src/clayde/claude.py
@@ -43,6 +43,14 @@ _LIMIT_PATTERNS = [
     "hit your limit",
 ]
 
+# Text patterns that indicate an authentication error in CLI error output.
+_AUTH_ERROR_PATTERNS = [
+    "not logged in",
+    "failed to authenticate",
+    "authentication_error",
+    "invalid authentication credentials",
+]
+
 
 @dataclasses.dataclass
 class InvocationResult:
@@ -446,6 +454,12 @@ def _is_limit_error(text: str) -> bool:
     return any(p in t for p in _LIMIT_PATTERNS)
 
 
+def _is_auth_error(text: str) -> bool:
+    """Return True if text contains an authentication error pattern."""
+    t = text.lower()
+    return any(p in t for p in _AUTH_ERROR_PATTERNS)
+
+
 def _make_cli_env() -> dict[str, str]:
     """Build an environment dict for CLI subprocess calls."""
     env = os.environ.copy()
@@ -613,6 +627,11 @@ class CliBackend(ClaudeBackend):
                     exc = UsageLimitError("Claude CLI usage limit hit")
                     span.record_exception(exc)
                     raise exc
+                if _is_auth_error(error_text):
+                    log.error("Claude CLI authentication failed")
+                    exc = RuntimeError("Claude CLI authentication failed")
+                    span.record_exception(exc)
+                    raise exc
 
             if result.returncode != 0:
                 log.error("Claude CLI exited with code %d", result.returncode)
@@ -652,8 +671,8 @@ class CliBackend(ClaudeBackend):
                 if _is_limit_error(error_text):
                     span.set_attribute("claude.available", False)
                     return False
-                if is_error and "not logged in" in error_text.lower():
-                    log.warning("Claude CLI is not logged in — marking unavailable")
+                if is_error and _is_auth_error(error_text):
+                    log.warning("Claude CLI authentication failed — marking unavailable")
                     span.set_attribute("claude.available", False)
                     return False
                 span.set_attribute("claude.available", True)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -888,6 +888,42 @@ class TestCliBackendInvoke:
         assert result.output == ""
         assert mock_run.call_count == 1
 
+    def test_auth_error_raises_runtime_error(self, tmp_path):
+        """is_error=True with auth failure raises RuntimeError instead of returning error text."""
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        auth_error_text = (
+            'Failed to authenticate. API Error: 401 {"type":"error","error":{'
+            '"type":"authentication_error","message":"Invalid authentication credentials"}}'
+        )
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"is_error": True, "result": auth_error_text})
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        backend = CliBackend()
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="authentication failed"):
+                backend.invoke("prompt", "/repo")
+
+    def test_not_logged_in_raises_runtime_error(self, tmp_path):
+        """is_error=True with 'not logged in' text raises RuntimeError."""
+        (tmp_path / "CLAUDE.md").write_text("identity")
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"is_error": True, "result": "Not logged in · Please run /login"})
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        backend = CliBackend()
+
+        with patch("clayde.claude.APP_DIR", tmp_path), \
+             patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="authentication failed"):
+                backend.invoke("prompt", "/repo")
+
 
 class TestCliBackendIsAvailable:
     def test_available_on_success(self):
@@ -919,6 +955,25 @@ class TestCliBackendIsAvailable:
         mock_result.stdout = '{"is_error": true, "result": "Not logged in \\u00b7 Please run /login"}'
         mock_result.stderr = ""
         mock_result.returncode = 1
+        backend = CliBackend()
+
+        with patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \
+             patch("clayde.claude._resolve_cli_bin", return_value="/usr/bin/claude"), \
+             patch("clayde.claude.subprocess.run", return_value=mock_result):
+            assert backend.is_available() is False
+
+    def test_unavailable_on_failed_to_authenticate(self):
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({
+            "is_error": True,
+            "result": (
+                "Failed to authenticate. API Error: 401 "
+                '{"type":"error","error":{"type":"authentication_error",'
+                '"message":"Invalid authentication credentials"}}'
+            ),
+        })
+        mock_result.stderr = ""
+        mock_result.returncode = 0
         backend = CliBackend()
 
         with patch("clayde.claude.get_settings", return_value=_mock_settings(backend="cli")), \


### PR DESCRIPTION
Closes #64

Added `_AUTH_ERROR_PATTERNS` list and `_is_auth_error()` helper in `claude.py`. In `CliBackend.invoke()`, auth errors ("failed to authenticate", "not logged in", "authentication_error", "invalid authentication credentials") are now detected after the usage-limit check and raise a clear `RuntimeError("Claude CLI authentication failed")` before the output reaches `parse_response()`. In `CliBackend.is_available()`, expanded the auth check from only `"not logged in"` to use `_is_auth_error()`, which also catches `"Failed to authenticate"` patterns from newer CLI versions. Added 3 new tests covering these cases.