### PR TITLE
fix(pebble): catch YAML parse errors in discover_skills; log worker failures

### DIFF
--- a/src/clayde/webhook/skills.py
+++ b/src/clayde/webhook/skills.py
@@ -108,7 +108,7 @@ def discover_skills(root: Path = SKILLS_ROOT) -> list[Skill]:
     for path in files:
         try:
             skill = _parse_skill(path)
-        except (ValueError, OSError) as e:
+        except Exception as e:
             log.warning("Failed to parse skill %s: %s", path, e)
             continue
         if skill.name in seen:

--- a/src/clayde/webhook/worker.py
+++ b/src/clayde/webhook/worker.py
@@ -138,5 +138,4 @@ async def worker_loop(queue: JobQueue, *, timeout_s: int, kb_path: str) -> None:
         try:
             await process_job(job, timeout_s=timeout_s, kb_path=kb_path)
         except Exception:
-            # process_job already emitted a notification + logged.
-            pass
+            log.exception("[%s] unhandled error in process_job", job.id)


### PR DESCRIPTION
## Summary

- **Root cause**: `api-azure` skill's frontmatter description contained `Triggers: "..."` unquoted — `yaml.safe_load` raised `ScannerError` (a `YAMLError`, not `ValueError`/`OSError`), which `discover_skills` didn't catch. The error escaped `process_job` before its inner try/except and was silently swallowed by `worker_loop`'s `except Exception: pass` with no log. The worker stayed alive but drained all pending jobs with silent failures, then blocked at `await queue.get()`.
- **`skills.py`**: widen `discover_skills` catch from `(ValueError, OSError)` to `Exception` — any malformed skill is warned and skipped, worker unaffected.
- **`worker.py`**: replace `pass` with `log.exception(...)` — unexpected errors from `process_job` are always visible.

Note: the `api-azure/SKILL.md` fix (quoting the description) lives in the knowledge base, not this repo.

## Test plan

- [ ] Add a skill file with a YAML colon in an unquoted value; verify `discover_skills` logs a warning and returns remaining skills without raising
- [ ] Verify worker logs `[job-id] unhandled error in process_job` when `process_job` raises unexpectedly
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)