### PR TITLE
feat(deploy): replace Watchtower with GH Actions pipeline deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,23 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: docker-compose.yml
+          target: /home/ubuntu/clayde/
+      - uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: cd ~/clayde && docker compose pull && docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./data/letsencrypt:/letsencrypt
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-
   clayde:
     image: ghcr.io/claydecode/me:main
     restart: unless-stopped
@@ -47,16 +44,9 @@ services:
       # handles cross-device sync; container performs no git on the KB.
       - ~/knowledge_base:/home/clayde/knowledge_base
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
       - "traefik.enable=true"
       - "traefik.http.routers.clayde.rule=Host(`${CLAYDE_PEBBLE_HOST}`) && PathPrefix(`/webhook`)"
       - "traefik.http.routers.clayde.entrypoints=websecure"
       - "traefik.http.routers.clayde.tls.certresolver=le"
       - "traefik.http.services.clayde.loadbalancer.server.port=8080"
 
-  watchtower:
-    image: containrrr/watchtower
-    restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 300 --cleanup --label-enable


### PR DESCRIPTION
## Summary

- Remove Watchtower service and its labels from `docker-compose.yml`
- Add `deploy` job to CI: SCPs `docker-compose.yml` to host, then SSHes in to `docker compose pull && docker compose up -d`
- Deploy runs only on push to `main`, after `build` succeeds

## Manual one-time setup (before merging)

```bash
ssh-keygen -t ed25519 -f deploy_key -N ""
ssh-copy-id -i deploy_key.pub ubuntu@clayde.net
# add deploy_key contents as GH secret DEPLOY_SSH_KEY
rm deploy_key deploy_key.pub
```

Add three secrets in repo Settings → Secrets → Actions:

| Secret | Value |
|--------|-------|
| `DEPLOY_HOST` | `clayde.net` |
| `DEPLOY_USER` | `ubuntu` |
| `DEPLOY_SSH_KEY` | Ed25519 private key PEM |

## Test Plan

- [ ] Secrets added to GH repo
- [ ] Merge to `main` → all three jobs pass (`test` → `build` → `deploy`)
- [ ] SSH into host: `docker ps` shows updated image, no watchtower container

🤖 Generated with [Claude Code](https://claude.com/claude-code)