### PR TITLE
chore(webhook): enable uvicorn access_log for ingress visibility

### DIFF
--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -372,7 +372,7 @@ async def _run_with_pebble() -> None:
     app = create_app(queue=queue, expected_token=settings.pebble_token)
     config = uvicorn.Config(
         app, host="0.0.0.0", port=settings.pebble_port,
-        log_level="info", access_log=False, lifespan="off",
+        log_level="info", access_log=True, lifespan="off",
     )
     server = uvicorn.Server(config)
 


### PR DESCRIPTION
## Summary
- Flip `access_log=False` → `True` on the uvicorn `Config` in `orchestrator.py:375`.
- Pebble webhooks fail silently when the request never enqueues (bad token → 401, wrong path → 404, schema mismatch → 422). With access logging off, none of those leave a trace.
- Today an investigation hit exactly this blind spot: two hours of "webhooks sent, no effect" with zero `clayde.pebble.enqueue` spans and no log lines either. Cause was unknowable without a request log.

## Test plan
- [ ] Rebuild + redeploy container, post a webhook with no auth → expect a 401 line in `docker logs clayde-clayde-1`.
- [ ] Post a valid webhook → expect a 200 line plus existing `[id] enqueued` log.
- [ ] Confirm no perf regression (access_log writes are cheap and webhook traffic is low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)