### PR TITLE
fix(freeshard): set GH_TOKEN in run_cycle so git push authenticates

### DIFF
--- a/src/clayde/freeshard/loop.py
+++ b/src/clayde/freeshard/loop.py
@@ -6,6 +6,7 @@ matching handler. No local state — all phase input comes from GitHub.
 """
 import concurrent.futures
 import logging
+import os
 
 from clayde.claude import is_claude_available
 from clayde.config import get_github_client
@@ -167,6 +168,11 @@ def run_cycle(settings) -> int:
         check_disk_and_alert(settings)
     except Exception:
         log.warning("Disk guard check failed — continuing")
+    if settings.github_token:
+        # The container's git credential helper is `!gh auth git-credential`,
+        # which reads GH_TOKEN from the environment; without it, branch pushes
+        # in steps._push_branch fail with exit 128.
+        os.environ["GH_TOKEN"] = settings.github_token
     if is_claude_available():
         g = get_github_client()
         return tick(g, settings)

--- a/tests/freeshard/test_loop.py
+++ b/tests/freeshard/test_loop.py
@@ -287,3 +287,21 @@ def test_malformed_issue_url_does_not_abort_tick(
     n = loop.tick(MagicMock(), _settings())
     assert n == 1
     mock_impl.assert_called_once()
+
+
+def test_run_cycle_sets_gh_token_for_git_credential_helper():
+    """run_cycle must export GH_TOKEN so the container's `!gh auth git-credential`
+    helper can authenticate branch pushes (else push fails with exit 128)."""
+    import os
+    from unittest.mock import MagicMock, patch
+    from clayde.freeshard import loop
+
+    settings = MagicMock(github_token="ghp_testtoken123")
+    os.environ.pop("GH_TOKEN", None)
+    with patch("clayde.freeshard.loop.check_disk_and_alert"), \
+         patch("clayde.freeshard.loop.is_claude_available", return_value=True), \
+         patch("clayde.freeshard.loop.get_github_client", return_value=MagicMock()), \
+         patch("clayde.freeshard.loop.tick", return_value=0):
+        loop.run_cycle(settings)
+    assert os.environ.get("GH_TOKEN") == "ghp_testtoken123"
+    os.environ.pop("GH_TOKEN", None)


### PR DESCRIPTION
Found by the supervised first run on FreeshardBase/documentation#2.

**Symptom:** the loop picked up the card, Claude implemented + committed (`373a482 chore: add generate-digest skill...`), local verify passed (docs has no test runner → green), but `git push origin clayde/issue-2` failed with **exit 128** — repeated every tick.

**Root cause:** the deployed container configures git with `credential.helper = !gh auth git-credential`, which authenticates by reading **`GH_TOKEN`** from the process environment. PR #97 removed the `os.environ["GH_TOKEN"] = settings.github_token` line (the review asked to assume git auth was already set). The git *identity* removal was fine — commits work — but the gh credential helper specifically needs `GH_TOKEN`, so pushes broke.

**Fix:** re-add `GH_TOKEN` export in `run_cycle` (the shared path for both the Pebble-integrated loop and the standalone entry). Verified independently: a dry-run push in the container with `GH_TOKEN` set → exit 0 (`* [new branch] clayde/issue-2`).

Suite 349 green (+1 test asserting `run_cycle` exports `GH_TOKEN`).

Unrelated: the run also exercised #94 live (no IMPLEMENT cap → re-ran Claude each tick on the push failure). I halted it by unassigning; the bounding fix stays tracked in #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)