### PR TITLE
Gate freeshard loop behind CLAYDE_FS_ENABLED (default off)

### DIFF
--- a/src/clayde/config.py
+++ b/src/clayde/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     # Orchestrator behaviour
     loop_interval_s: int = 300
     implement_max_retries: int = 3
+    fs_enabled: bool = False
     fs_reviewer: str = "max-tet"
     fs_parallelism: int = 1
     fs_loop_interval_s: int = 120

--- a/src/clayde/orchestrator.py
+++ b/src/clayde/orchestrator.py
@@ -58,7 +58,13 @@ async def _run_with_pebble() -> None:
             kb_path=settings.kb_path,
         )
 
-    await asyncio.gather(server.serve(), worker_task(), _freeshard_loop(settings))
+    tasks = [server.serve(), worker_task()]
+    if settings.fs_enabled:
+        log.info("Freeshard loop enabled")
+        tasks.append(_freeshard_loop(settings))
+    else:
+        log.info("Freeshard loop disabled (CLAYDE_FS_ENABLED not set)")
+    await asyncio.gather(*tasks)
 
 
 def run_loop():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,3 +158,9 @@ def test_kb_path_default():
     from clayde.config import Settings
     s = Settings(_env_file=None)
     assert s.kb_path == "/home/clayde/knowledge_base"
+
+
+def test_fs_enabled_defaults_off():
+    from clayde.config import Settings
+    s = Settings(_env_file=None)
+    assert s.fs_enabled is False


### PR DESCRIPTION
## What

Adds a config switch, `CLAYDE_FS_ENABLED` (`Settings.fs_enabled`, default **False**), that gates the freeshard issue-grinding loop. When the container runs with the Pebble webhook (`_run_with_pebble`), the loop is now opt-in:

- `server.serve()` (Pebble webhook) and `worker_task()` (Pebble worker) **always** run.
- `_freeshard_loop(settings)` is scheduled **only** when `settings.fs_enabled` is true.
- A one-line `log.info` at startup states whether the loop is enabled or disabled, so container state is visible in the logs.

## Why

The freeshard loop previously ran unconditionally alongside Pebble. This makes it possible to keep Pebble (and the worker) serving while turning the issue loop off. Defaulting the switch off means the loop must be explicitly enabled via `CLAYDE_FS_ENABLED` in the container's config.env.

## Tests

- Added `test_fs_enabled_defaults_off` confirming the field defaults to False.
- Full suite green: **364 passed**.
- The `asyncio.gather` task-selection wiring lives in the async container entrypoint (`_run_with_pebble`); exercising it directly would require heavy event-loop/uvicorn mocking for little value, so it is covered by manual deploy verification rather than a unit test. The behaviour is a simple conditional `tasks.append`.

## Note

This PR does **not** change `config.env` or redeploy — enabling the loop in the running container is a separate follow-up step.

## Recommended reading order

1. `src/clayde/config.py` — new `fs_enabled` field.
2. `src/clayde/orchestrator.py` — conditional scheduling of `_freeshard_loop`.
3. `tests/test_config.py` — default-off test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)